### PR TITLE
Send the "pusher:subscription_succeeded" event

### DIFF
--- a/Source/PusherSwift.swift
+++ b/Source/PusherSwift.swift
@@ -256,6 +256,10 @@ public class PusherConnection: WebSocketDelegate {
     private func handleSubscriptionSucceededEvent(json: PusherEventJSON) {
         if let channelName = json["channel"] as? String, chan = self.channels.find(channelName) {
             chan.subscribed = true
+            if let eData = json["data"] as? String {
+                callGlobalCallbacks("pusher:subscription_succeeded", jsonObject: json)
+                chan.handleEvent("pusher:subscription_succeeded", eventData: eData)
+            }
             if isPresenceChannel(channelName) {
                 if let presChan = self.channels.find(channelName) as? PresencePusherChannel {
                     if let data = json["data"] as? String, dataJSON = getPusherEventJSONFromString(data) {
@@ -367,9 +371,9 @@ public class PusherConnection: WebSocketDelegate {
     }
 
     private func callGlobalCallbacks(eventName: String, jsonObject: Dictionary<String,AnyObject>) {
-        if let channelName = jsonObject["channel"] as? String, eName = jsonObject["event"] as? String, eData =  jsonObject["data"] as? String {
+        if let channelName = jsonObject["channel"] as? String, eData =  jsonObject["data"] as? String {
             if let globalChannel = self.globalChannel {
-                globalChannel.handleEvent(channelName, eventName: eName, eventData: eData)
+                globalChannel.handleEvent(channelName, eventName: eventName, eventData: eData)
             }
         }
     }

--- a/Tests/PusherSwiftTests.swift
+++ b/Tests/PusherSwiftTests.swift
@@ -424,6 +424,31 @@ class PusherTopLevelApiSpec: QuickSpec {
                     let testChannel = pusher.connection.channels.channels["test-channel"]
                     expect(testChannel?.subscribed).to(beTruthy())
                 }
+                
+                it("subscription succeeded event sent to global channel") {
+                    let callback = { (data: AnyObject?) -> Void in
+                        if let eName = data?["event"] where eName == "pusher:subscription_succeeded" {
+                            socket.appendToCallbackCheckString("globalCallbackCalled")
+                        }
+                    }
+                    pusher.bind(callback)
+                    expect(socket.callbackCheckString).to(equal(""))
+                    pusher.subscribe("test-channel")
+                    expect(socket.callbackCheckString).to(equal("globalCallbackCalled"))
+                }
+                
+                it("subscription succeeded event sent to private channel") {
+                    let callback = { (data: AnyObject?) -> Void in
+                        if let eName = data?["event"] where eName == "pusher:subscription_succeeded" {
+                            socket.appendToCallbackCheckString("channelCallbackCalled")
+                        }
+                    }
+                    pusher.bind(callback)
+                    expect(socket.callbackCheckString).to(equal(""))
+                    let chan = pusher.subscribe("test-channel")
+                    chan.bind("pusher:subscription_succeeded", callback: callback)
+                    expect(socket.callbackCheckString).to(equal("channelCallbackCalled"))
+                }
 
                 it("sets up the channel correctly") {
                     let chan = pusher.subscribe("test-channel")


### PR DESCRIPTION
This makes it possible to implement a [message history use case](https://blog.pusher.com/how-to-add-message-history-to-your-pusher-apps/) like that outlined on the Pusher website. 

I used the pusher [JS library](https://github.com/pusher/pusher-js) for reference while implementing. 