### PR TITLE
Dispatch Errors on Main Thread

### DIFF
--- a/Source/PusherConnection.swift
+++ b/Source/PusherConnection.swift
@@ -314,7 +314,9 @@ public class PusherConnection {
             "channel": channelName,
             "data": data ?? ""
         ]
-        handleEvent(eventName, jsonObject: json)
+        dispatch_async(dispatch_get_main_queue()) {
+            self.handleEvent(eventName, jsonObject: json)
+        }
     }
 
     /**

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -69,13 +69,14 @@ class AuthenticationSpec: QuickSpec {
 
                 pusher.bind({ (data: AnyObject?) -> Void in
                     if let data = data as? [String: AnyObject], eventName = data["event"] as? String where eventName == "pusher:subscription_error" {
+                        expect(NSThread.isMainThread()).to(equal(true))
                         stubber.stub("subscriptionErrorCallback", args: [eventName], functionToCall: nil)
                     }
                 })
 
                 pusher.connect()
-                expect(stubber.calls.last?.name).to(equal("subscriptionErrorCallback"))
-                expect(stubber.calls.last?.args?.last as? String).to(equal("pusher:subscription_error"))
+                expect(stubber.calls.last?.name).toEventually(equal("subscriptionErrorCallback"))
+                expect(stubber.calls.last?.args?.last as? String).toEventually(equal("pusher:subscription_error"))
             }
         }
     }

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -247,7 +247,9 @@ class MockSession: NSURLSession {
             self.completionHandler = completionHandler
         }
         override func resume() {
-            completionHandler!(mockResponse.data, mockResponse.urlResponse, mockResponse.error)
+            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+                self.completionHandler!(self.mockResponse.data, self.mockResponse.urlResponse, self.mockResponse.error)
+            }
         }
     }
 }


### PR DESCRIPTION
The other handlers are called by Starscream's delegate, but the auth
errors are called by `NSUrlSession`, which is on a background thread.

So, I've moved the logic into a `dispatch_async` on the main thread.
I decided to put it in the handleError method rather than outside it because
there are multiple places that need it and currently all of them are on the
background threads.

If later that's not true, then we should put the dispatch around the method
call in all 4 or so places it comes up.