### PR TITLE
Feature/authrequestcustomizer improvements

### DIFF
--- a/Source/PusherClientOptions.swift
+++ b/Source/PusherClientOptions.swift
@@ -16,7 +16,7 @@ public struct PusherClientOptions {
     public let host: String?
     public let port: Int?
     public let autoReconnect: Bool?
-    public let authRequestCustomizer: (NSMutableURLRequest -> NSMutableURLRequest)?
+    public let authRequestCustomizer: ((endpoint: String, socket: String, channel: PusherChannel) -> NSMutableURLRequest)?
     public let debugLogger: ((String) -> ())?
 
     /**
@@ -89,7 +89,7 @@ public struct PusherClientOptions {
         self.host = optionsMergedWithDefaults["host"] as? String
         self.port = optionsMergedWithDefaults["port"] as? Int
         self.autoReconnect = optionsMergedWithDefaults["autoReconnect"] as? Bool
-        self.authRequestCustomizer = optionsMergedWithDefaults["authRequestCustomizer"] as? (NSMutableURLRequest -> NSMutableURLRequest)
+        self.authRequestCustomizer = optionsMergedWithDefaults["authRequestCustomizer"] as? ((String, String, PusherChannel) -> NSMutableURLRequest)
         self.debugLogger = optionsMergedWithDefaults["debugLogger"] as? (String) -> ()
 
         if let _ = authEndpoint {

--- a/Source/PusherConnection.swift
+++ b/Source/PusherConnection.swift
@@ -519,7 +519,7 @@ public class PusherConnection {
         request.HTTPBody = "socket_id=\(socket)&channel_name=\(channel.name)".dataUsingEncoding(NSUTF8StringEncoding)
 
         if let handler = self.options.authRequestCustomizer {
-            request = handler(request)
+            request = handler(endpoint: endpoint, socket: socket, channel: channel)
         }
 
         let task = URLSession.dataTaskWithRequest(request, completionHandler: { data, response, error in

--- a/Tests/PusherClientInitializationTests.swift
+++ b/Tests/PusherClientInitializationTests.swift
@@ -111,8 +111,8 @@ class PusherClientInitializationSpec: QuickSpec {
 
                 context("an authRequestCustomizer") {
                     it("has one set") {
-                        func customizer(request: NSMutableURLRequest) -> NSMutableURLRequest {
-                            return request
+                        func customizer(endpoint: String, socket: String, channel: PusherChannel) -> NSMutableURLRequest {
+                            return NSMutableURLRequest()
                         }
                         pusher = Pusher(key: key, options: ["authRequestCustomizer": customizer])
                         expect(pusher.connection.options.authRequestCustomizer).toNot(beNil())


### PR DESCRIPTION
Passing a `NSMutableURLRequest` into the `authRequestCustomizer` isn't very helpful when the customizer needs the socket, so doing it this way gives the customizer everything it needs.