### PR TITLE
More reliable reconnect

### DIFF
--- a/Source/PusherConnection.swift
+++ b/Source/PusherConnection.swift
@@ -17,15 +17,18 @@ public class PusherConnection {
     public var socket: WebSocket!
     public var URLSession: NSURLSession
     public weak var stateChangeDelegate: ConnectionStateChangeDelegate?
+    internal var reconnectOperation: NSOperation?
 
     public lazy var reachability: Reachability? = {
         let reachability = try? Reachability.reachabilityForInternetConnection()
         reachability?.whenReachable = { [unowned self] reachability in
+            self.reconnectOperation?.cancel()
             if self.connectionState == .Disconnected {
                 self.socket.connect()
             }
         }
         reachability?.whenUnreachable = { [unowned self] reachability in
+            self.reconnectOperation?.cancel()
             print("Network unreachable")
         }
         return reachability

--- a/Source/PusherWebsocketDelegate.swift
+++ b/Source/PusherWebsocketDelegate.swift
@@ -40,16 +40,18 @@ extension PusherConnection: WebSocketDelegate {
             channel.subscribed = false
         }
 
-        let operation = NSBlockOperation {
-            self.socket.connect()
-        }
+        if let reconnect = self.options.autoReconnect where reconnect {
+            let operation = NSBlockOperation {
+                self.socket.connect()
+            }
 
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(NSEC_PER_SEC)), dispatch_get_main_queue()) {
-            NSOperationQueue.mainQueue().addOperation(operation)
-        }
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(NSEC_PER_SEC)), dispatch_get_main_queue()) {
+                NSOperationQueue.mainQueue().addOperation(operation)
+            }
 
-        self.reconnectOperation?.cancel()
-        self.reconnectOperation = operation
+            self.reconnectOperation?.cancel()
+            self.reconnectOperation = operation
+        }
     }
 
     public func websocketDidConnect(ws: WebSocket) {}

--- a/Source/PusherWebsocketDelegate.swift
+++ b/Source/PusherWebsocketDelegate.swift
@@ -41,16 +41,18 @@ extension PusherConnection: WebSocketDelegate {
         }
 
         if let reconnect = self.options.autoReconnect where reconnect {
-            let operation = NSBlockOperation {
-                self.socket.connect()
-            }
+            if let reachability = self.reachability where reachability.isReachable() {
+                let operation = NSBlockOperation {
+                    self.socket.connect()
+                }
 
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(NSEC_PER_SEC)), dispatch_get_main_queue()) {
-                NSOperationQueue.mainQueue().addOperation(operation)
-            }
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(NSEC_PER_SEC)), dispatch_get_main_queue()) {
+                    NSOperationQueue.mainQueue().addOperation(operation)
+                }
 
-            self.reconnectOperation?.cancel()
-            self.reconnectOperation = operation
+                self.reconnectOperation?.cancel()
+                self.reconnectOperation = operation
+            }
         }
     }
 

--- a/Source/PusherWebsocketDelegate.swift
+++ b/Source/PusherWebsocketDelegate.swift
@@ -39,6 +39,17 @@ extension PusherConnection: WebSocketDelegate {
         for (_, channel) in self.channels.channels {
             channel.subscribed = false
         }
+
+        let operation = NSBlockOperation {
+            self.socket.connect()
+        }
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(NSEC_PER_SEC)), dispatch_get_main_queue()) {
+            NSOperationQueue.mainQueue().addOperation(operation)
+        }
+
+        self.reconnectOperation?.cancel()
+        self.reconnectOperation = operation
     }
 
     public func websocketDidConnect(ws: WebSocket) {}


### PR DESCRIPTION
I'm interested to hear your thoughts on this.

Currently there's no reconnect logic except to connect again when the network becomes reachable.
That's fine if the websocket only closes due to network unreachability, but there are other cases that also might happen.

The remote end could close the connection probably, but the one I saw was that the app goes to sleep in the background, and 20 minutes later comes back to the foreground.

In this case everything is still like it was, but the websocket is closed.
Reachability doesn't fire, though, because reachability hasn't changed.

So, this sets up a reconnect when the websocket dies, but cancels it if we hear from reachability for any reason.
Thoughts?