### PR TITLE
Moving socketId assignment to before changed connectionState

### DIFF
--- a/Source/PusherConnection.swift
+++ b/Source/PusherConnection.swift
@@ -278,8 +278,8 @@ public class PusherConnection {
     private func handleConnectionEstablishedEvent(json: PusherEventJSON) {
         if let data = json["data"] as? String {
             if let connectionData = getPusherEventJSONFromString(data), socketId = connectionData["socket_id"] as? String {
-                updateConnectionState(.Connected)
                 self.socketId = socketId
+                updateConnectionState(.Connected)
 
                 self.reconnectAttempts = 0
                 self.reconnectTimer?.invalidate()


### PR DESCRIPTION
`socketId` needs to be assigned before calling `updateConnectionState`, otherwise `socketId` is always `nil`.