### PR TITLE
allow authRequestBuilder's to fail when creating requests for authorization

### DIFF
--- a/Source/PusherClientOptions.swift
+++ b/Source/PusherClientOptions.swift
@@ -19,7 +19,7 @@ public enum PusherHost {
 }
 
 public protocol AuthRequestBuilderProtocol {
-    func requestFor(socketID: String, channel: PusherChannel) -> NSMutableURLRequest
+    func requestFor(socketID: String, channel: PusherChannel) -> NSMutableURLRequest?
 }
 
 public enum AuthMethod {

--- a/Source/PusherConnection.swift
+++ b/Source/PusherConnection.swift
@@ -461,9 +461,13 @@ public class PusherConnection {
                         sendAuthorisationRequest(request, channel: channel, callback: callback)
                         return true
                     case .AuthRequestBuilder(authRequestBuilder: let builder):
-                        let request = builder.requestFor(socketID, channel: channel)
-                        sendAuthorisationRequest(request, channel: channel, callback: callback)
-                        return true
+                        if let request = builder.requestFor(socketID, channel: channel) {
+                            sendAuthorisationRequest(request, channel: channel, callback: callback)
+                            
+                            return true
+                        } else {
+                            return false
+                        }
                     case .Internal(secret: let secret):
                         var msg = ""
                         var channelData = ""

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -91,7 +91,7 @@ class AuthenticationSpec: QuickSpec {
 
             it("should make the request created by something conforming to the AuthRequestBuilderProtocol") {
                 struct AuthRequestBuilder: AuthRequestBuilderProtocol {
-                    func requestFor(socketID: String, channel: PusherChannel) -> NSMutableURLRequest {
+                    func requestFor(socketID: String, channel: PusherChannel) -> NSMutableURLRequest? {
                         let request = NSMutableURLRequest(URL: NSURL(string: "http://localhost:9292/builder")!)
                         request.HTTPMethod = "POST"
                         request.HTTPBody = "socket_id=\(socketID)&channel_name=\(channel.name)".dataUsingEncoding(NSUTF8StringEncoding)


### PR DESCRIPTION
By returning a non-optional we don't allow conforming objects to fail to create requests, which is possible.