### PR TITLE
Quick fix for a couple of memory leaks.

### DIFF
--- a/Source/NativePusher.swift
+++ b/Source/NativePusher.swift
@@ -25,7 +25,7 @@
     private var failedRequestAttempts: Int = 0
     private let maxFailedRequestAttempts: Int = 6
 
-    internal var delegate: PusherDelegate? = nil
+    internal weak var delegate: PusherDelegate? = nil
 
     internal var requestQueue = TaskQueue()
 

--- a/Source/PusherChannel.swift
+++ b/Source/PusherChannel.swift
@@ -34,7 +34,7 @@ open class PusherChannel: NSObject {
     open var eventHandlers: [String: [EventHandler]] = [:]
     open var subscribed = false
     open let name: String
-    open let connection: PusherConnection
+    open weak var connection: PusherConnection?
     open var unsentEvents = [PusherEvent]()
     open let type: PusherChannelType
 
@@ -110,10 +110,10 @@ open class PusherChannel: NSObject {
     */
     open func handleEvent(name: String, data: String) {
         if let eventHandlerArray = self.eventHandlers[name] {
-            let jsonize = connection.options.attemptToReturnJSONObject
+            let jsonize = connection?.options.attemptToReturnJSONObject ?? false
 
             for eventHandler in eventHandlerArray {
-                eventHandler.callback(jsonize ? connection.getEventDataJSON(from: data) : data)
+                eventHandler.callback(jsonize ? connection?.getEventDataJSON(from: data) : data)
             }
         }
     }
@@ -127,7 +127,7 @@ open class PusherChannel: NSObject {
     */
     open func trigger(eventName: String, data: Any) {
         if subscribed {
-            self.connection.sendEvent(event: eventName, data: data, channel: self)
+            connection?.sendEvent(event: eventName, data: data, channel: self)
         } else {
             unsentEvents.insert(PusherEvent(name: eventName, data: data), at: 0)
         }


### PR DESCRIPTION
Fixes memory leaks as described in https://github.com/pusher/pusher-websocket-swift/issues/101

Note that this is just a quick fix for the issue that's affecting us and causing pretty big memory leaks. I think that a better fix would be to refactor how `PusherChannel` uses the facilities provided by `PusherConnection` as now it's just given the entire class instance to use.