### PR TITLE
Remove connection race

### DIFF
--- a/Source/PusherWebsocketDelegate.swift
+++ b/Source/PusherWebsocketDelegate.swift
@@ -38,6 +38,9 @@ extension PusherConnection: WebSocketDelegate {
             }
         }
 
+        self.connectionEstablishedMessageReceived = false
+        self.socketConnected = false
+
         // Handle error (if any)
         guard let error = error, error.code != Int(WebSocket.CloseCode.normal.rawValue) else {
             self.delegate?.debugLog?(message: "[PUSHER DEBUG] Deliberate disconnection - skipping reconnect attempts")
@@ -102,7 +105,9 @@ extension PusherConnection: WebSocketDelegate {
         reconnectAttempts += 1
     }
 
+    public func websocketDidConnect(socket ws: WebSocket) {
+        self.socketConnected = true
+    }
 
-    public func websocketDidConnect(socket ws: WebSocket) {}
     public func websocketDidReceiveData(socket ws: WebSocket, data: Data) {}
 }

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -33,6 +33,7 @@ open class MockWebSocket: WebSocket {
             functionToCall: {
                 if let delegate = self.delegate {
                     delegate.websocketDidReceiveMessage(socket: self, text: connectionEstablishedString)
+                    delegate.websocketDidConnect(socket: self)
                 } else {
                     print("Your socket delegate is nil")
                 }


### PR DESCRIPTION
Remove the connection state race where the message saying `connection_established` from Pusher's servers is potentially received before the websocket itself has deemed itself as connected (which would stop it from then writing data over the socket .e.g. subscription requests).