### PR TITLE
Manual auth

### DIFF
--- a/Source/ObjectiveC.swift
+++ b/Source/ObjectiveC.swift
@@ -11,8 +11,22 @@ public extension Pusher {
         return self.subscribe(channelName, onMemberAdded: nil, onMemberRemoved: nil)
     }
 
+    @objc public func subscribe(
+        channelName: String,
+        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil) -> PusherChannel {
+            return self.subscribe(channelName, auth: nil, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
+    }
+
     @objc public func subscribeToPresenceChannel(channelName: String) -> PusherPresenceChannel {
-        return self.subscribeToPresenceChannel(channelName: channelName, onMemberAdded: nil, onMemberRemoved: nil)
+        return self.subscribeToPresenceChannel(channelName: channelName, auth: nil, onMemberAdded: nil, onMemberRemoved: nil)
+    }
+
+    @objc public func subscribeToPresenceChannel(
+        channelName: String,
+        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil) -> PusherPresenceChannel {
+            return self.subscribeToPresenceChannel(channelName: channelName, auth: nil, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
     }
 
     @objc public convenience init(withAppKey key: String, options: PusherClientOptions) {

--- a/Source/PusherChannel.swift
+++ b/Source/PusherChannel.swift
@@ -10,11 +10,11 @@ public enum PusherChannelType {
     case `private`
     case presence
     case normal
-    
+
     public init(name: String) {
         self = type(of: self).type(forName: name)
     }
-    
+
     public static func type(forName name: String) -> PusherChannelType {
         if (name.components(separatedBy: "-")[0] == "presence") {
             return .presence
@@ -24,7 +24,7 @@ public enum PusherChannelType {
             return .normal
         }
     }
-    
+
     public static func isPresenceChannel(name: String) -> Bool {
         return PusherChannelType(name: name) == .presence
     }
@@ -37,18 +37,22 @@ open class PusherChannel: NSObject {
     open weak var connection: PusherConnection?
     open var unsentEvents = [PusherEvent]()
     open let type: PusherChannelType
+    public var auth: PusherAuth?
 
     /**
         Initializes a new PusherChannel with a given name and conenction
 
         - parameter name:       The name of the channel
         - parameter connection: The connection that this channel is relevant to
+        - parameter auth:       A PusherAuth value if subscription is being made to an
+                                authenticated channel without using the default auth methods
 
         - returns: A new PusherChannel instance
     */
-    public init(name: String, connection: PusherConnection) {
+    public init(name: String, connection: PusherConnection, auth: PusherAuth? = nil) {
         self.name = name
         self.connection = connection
+        self.auth = auth
         self.type = PusherChannelType(name: name)
     }
 

--- a/Source/PusherChannels.swift
+++ b/Source/PusherChannels.swift
@@ -15,6 +15,8 @@ open class PusherChannels: NSObject {
 
         - parameter name:            The name of the channel to create
         - parameter connection:      The connection associated with the channel being created
+        - parameter auth:            A PusherAuth value if subscription is being made to an
+                                     authenticated channel without using the default auth methods
         - parameter onMemberAdded:   A function that will be called with information about the
                                      member who has just joined the presence channel
         - parameter onMemberRemoved: A function that will be called with information about the
@@ -25,6 +27,7 @@ open class PusherChannels: NSObject {
     internal func add(
         name: String,
         connection: PusherConnection,
+        auth: PusherAuth? = nil,
         onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil) -> PusherChannel {
             if let channel = self.channels[name] {
@@ -35,11 +38,12 @@ open class PusherChannels: NSObject {
                     newChannel = PusherPresenceChannel(
                         name: name,
                         connection: connection,
+                        auth: auth,
                         onMemberAdded: onMemberAdded,
                         onMemberRemoved: onMemberRemoved
                     )
                 } else {
-                    newChannel = PusherChannel(name: name, connection: connection)
+                    newChannel = PusherChannel(name: name, connection: connection, auth: auth)
                 }
                 self.channels[name] = newChannel
                 return newChannel
@@ -52,6 +56,8 @@ open class PusherChannels: NSObject {
 
         - parameter channelName:     The name of the channel to create
         - parameter connection:      The connection associated with the channel being created
+        - parameter auth:            A PusherAuth value if subscription is being made to an
+                                     authenticated channel without using the default auth methods
         - parameter onMemberAdded:   A function that will be called with information about the
                                      member who has just joined the presence channel
         - parameter onMemberRemoved: A function that will be called with information about the
@@ -62,6 +68,7 @@ open class PusherChannels: NSObject {
     internal func addPresence(
         channelName: String,
         connection: PusherConnection,
+        auth: PusherAuth? = nil,
         onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil) -> PusherPresenceChannel {
         if let channel = self.channels[channelName] as? PusherPresenceChannel {
@@ -70,6 +77,7 @@ open class PusherChannels: NSObject {
             let newChannel = PusherPresenceChannel(
                 name: channelName,
                 connection: connection,
+                auth: auth,
                 onMemberAdded: onMemberAdded,
                 onMemberRemoved: onMemberRemoved
             )

--- a/Source/PusherPresenceChannel.swift
+++ b/Source/PusherPresenceChannel.swift
@@ -20,6 +20,8 @@ open class PusherPresenceChannel: PusherChannel {
 
         - parameter name:            The name of the channel
         - parameter connection:      The connection that this channel is relevant to
+        - parameter auth:            A PusherAuth value if subscription is being made to an
+                                     authenticated channel without using the default auth methods
         - parameter onMemberAdded:   A function that will be called with information about the
                                      member who has just joined the presence channel
         - parameter onMemberRemoved: A function that will be called with information about the
@@ -30,12 +32,13 @@ open class PusherPresenceChannel: PusherChannel {
     init(
         name: String,
         connection: PusherConnection,
+        auth: PusherAuth? = nil,
         onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil) {
             self.members = []
             self.onMemberAdded = onMemberAdded
             self.onMemberRemoved = onMemberRemoved
-            super.init(name: name, connection: connection)
+            super.init(name: name, connection: connection, auth: auth)
     }
 
     /**

--- a/Source/PusherSwift.swift
+++ b/Source/PusherSwift.swift
@@ -71,6 +71,8 @@ let CLIENT_NAME = "pusher-websocket-swift"
         Subscribes the client to a new channel
 
         - parameter channelName:     The name of the channel to subscribe to
+        - parameter auth:            A PusherAuth value if subscription is being made to an
+                                     authenticated channel without using the default auth methods
         - parameter onMemberAdded:   A function that will be called with information about the
                                      member who has just joined the presence channel
         - parameter onMemberRemoved: A function that will be called with information about the
@@ -80,9 +82,15 @@ let CLIENT_NAME = "pusher-websocket-swift"
     */
     open func subscribe(
         _ channelName: String,
+        auth: PusherAuth? = nil,
         onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil) -> PusherChannel {
-            return self.connection.subscribe(channelName: channelName, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
+            return self.connection.subscribe(
+                channelName: channelName,
+                auth: auth,
+                onMemberAdded: onMemberAdded,
+                onMemberRemoved: onMemberRemoved
+            )
     }
 
     /**
@@ -91,18 +99,26 @@ let CLIENT_NAME = "pusher-websocket-swift"
         generic channel object (which you can then cast)
 
         - parameter channelName:     The name of the channel to subscribe to
+        - parameter auth:            A PusherAuth value if subscription is being made to an
+                                     authenticated channel without using the default auth methods
         - parameter onMemberAdded:   A function that will be called with information about the
-        member who has just joined the presence channel
+                                     member who has just joined the presence channel
         - parameter onMemberRemoved: A function that will be called with information about the
-        member who has just left the presence channel
+                                     member who has just left the presence channel
 
         - returns: A new PusherPresenceChannel instance
     */
     open func subscribeToPresenceChannel(
         channelName: String,
+        auth: PusherAuth? = nil,
         onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil) -> PusherPresenceChannel {
-            return self.connection.subscribeToPresenceChannel(channelName: channelName, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
+            return self.connection.subscribeToPresenceChannel(
+                channelName: channelName,
+                auth: auth,
+                onMemberAdded: onMemberAdded,
+                onMemberRemoved: onMemberRemoved
+            )
     }
 
     /**

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -208,4 +208,42 @@ class AuthenticationTests: XCTestCase {
 
         waitForExpectations(timeout: 0.5)
     }
+
+    func testSubscribingToAPrivateChannelWhenAnAuthValueIsProvidedShouldWork() {
+        let ex = expectation(description: "the channel should be subscribed to successfully")
+        let channelName = "private-manual-auth"
+
+        let dummyDelegate = DummyDelegate()
+        dummyDelegate.ex = ex
+        dummyDelegate.testingChannelName = channelName
+        pusher.delegate = dummyDelegate
+
+        let chan = pusher.subscribe(channelName, auth: PusherAuth(auth: "testKey123:12345678gfder78ikjbgmanualauth"))
+        XCTAssertFalse(chan.subscribed, "the channel should not be subscribed")
+        pusher.connect()
+
+        waitForExpectations(timeout: 0.5)
+    }
+
+    func testSubscribingToAPresenceChannelWhenAnAuthValueIsProvidedShouldWork() {
+        let ex = expectation(description: "the channel should be subscribed to successfully")
+        let channelName = "presence-manual-auth"
+
+        let dummyDelegate = DummyDelegate()
+        dummyDelegate.ex = ex
+        dummyDelegate.testingChannelName = channelName
+        pusher.delegate = dummyDelegate
+
+        let chan = pusher.subscribe(
+            channelName,
+            auth: PusherAuth(
+                auth: "testKey123:12345678gfder78ikjbgmanualauth",
+                channelData: "{\"user_id\":16,\"user_info\":{\"time\":\"2017-02-20 14:54:36 +0000\"}}"
+            )
+        )
+        XCTAssertFalse(chan.subscribed, "the channel should not be subscribed")
+        pusher.connect()
+
+        waitForExpectations(timeout: 0.5)
+    }
 }

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -106,6 +106,22 @@ open class MockWebSocket: WebSocket {
                     self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-test-channel\",\"data\":\"{}\"}")
                 }
             )
+        } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:12345678gfder78ikjbgmanualauth", "private-manual-auth"]) {
+            let _ = stubber.stub(
+                functionName: "writeString",
+                args: [string],
+                functionToCall: {
+                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-manual-auth\",\"data\":\"{}\"}")
+                }
+            )
+        } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:12345678gfder78ikjbgmanualauth", "presence-manual-auth"]) {
+            let _ = stubber.stub(
+                functionName: "writeString",
+                args: [string],
+                functionToCall: {
+                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"presence-manual-auth\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"16\\\"],\\\"hash\\\":{\\\"16\\\":{\\\"twitter\\\":\\\"hamchapman\\\"}}}}\"}")
+                }
+            )
         } else if stringContainsElements(string, elements: ["key:0d0d2e7c2cd967246d808180ef0f115dad51979e48cac9ad203928141f9e6a6f", "private-test-channel", "pusher:subscribe"]) {
             let _ = stubber.stub(
                 functionName: "writeString",


### PR DESCRIPTION
Updates the `subscribe` and `subscribeToPresenceChannel` functions to accept and optional `auth` parameter of type `PusherAuth`.

This `PusherAuth` object can be initialised with just an `auth (String)` value if the subscription is to a private channel, or both an `auth (String)` and `channelData (String)` pair of values if the subscription is to a presence channel.

These `auth` and `channelData` values are the values that you received if the json object created by a call to `pusher.authenticate(...)` in one of our various Ruby libraries.

Keep in mind that in order to generate a valid `auth` value for a subscription the `socketId` (i.e. the unique identifier for a web socket connection to the Pusher servers) must be present when the `auth` value is generated. As such, the likely flow for using this is something like this:

```swift
import UIKit
import PusherSwift

class ViewController: UIViewController, PusherDelegate {
    var pusher: Pusher! = nil

    override func viewDidLoad() {
        super.viewDidLoad()

        let optionsWithEndpoint = PusherClientOptions(
            authMethod: AuthMethod.endpoint(authEndpoint: "https://some.endpoint.for.non.manual.auth")
        )
        pusher = Pusher(key: "your-app-key", options: optionsWithEndpoint)
        pusher.delegate = self
        pusher.connect()
    }

    // PusherDelegate methods

    func changedConnectionState(from old: ConnectionState, to new: ConnectionState) {
        // print the old and new connection states
        print("old: \(old.stringValue()) -> new: \(new.stringValue())")

        // we know we are connected here as we have a socketId
        if let socketId = pusher.connection.socketId {
            // a dummy channel name value here, just as an example
            let channelName = "presence-test"

            getAuthData(channelName: channelName, socketId: socketId, completionHandler: { res in
                // the response from the server looks like: `{ "auth": "123123abcabc123", "channel_data": "{\"user_id\":16,\"user_info\":{\"time\":\"2017-02-20 14:54:36 +0000\"}}"}
                let pusherAuth = PusherAuth(auth: res["auth"]!, channelData: res["channel_data"]!)
                let _ = self.pusher.subscribe(channelName, auth: pusherAuth)
            })
        }
    }

    func getAuthData(channelName: String, socketId: String, completionHandler: @escaping ([String: String]) -> ()) {
        var request = URLRequest(url: URL(string: "https://yourendpointforcreatingauthvalues.com")!)
        request.httpMethod = "POST"
        request.httpBody = "socket_id=\(socketId)&channel_name=\(channelName)".data(using: String.Encoding.utf8)

        let task = URLSession.shared.dataTask(with: request, completionHandler: { data, response, sessionError in
            guard let data = data else {
                print("No data")
                return
            }

            guard let httpResponse = response as? HTTPURLResponse, (httpResponse.statusCode == 200 || httpResponse.statusCode == 201) else {
                let dataString = String(data: data, encoding: String.Encoding.utf8)
                print ("Error getting auth data for [\(channelName)]: \(dataString)")
                return
            }

            guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []), let json = jsonObject as? [String: String] else {
                print("Error parsing response data")
                return
            }

            completionHandler(json)
        })

        task.resume()
    }
}
```