### PR TITLE
Add authorizer

### DIFF
--- a/PusherSwift/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift/PusherSwift.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		3389F5721CAEDDF300563F49 /* PusherChannels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3389F5711CAEDDF300563F49 /* PusherChannels.swift */; };
 		3389F5761CAEDE2800563F49 /* PusherGlobalChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3389F5751CAEDE2800563F49 /* PusherGlobalChannel.swift */; };
 		3389F57A1CAEDEC800563F49 /* PusherClientOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3389F5791CAEDEC800563F49 /* PusherClientOptions.swift */; };
+		3390D1E61F054D0400E1944D /* AuthRequestBuilderProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3390D1E51F054D0400E1944D /* AuthRequestBuilderProtocol.swift */; };
+		3390D1E81F054D1E00E1944D /* Authorizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3390D1E71F054D1E00E1944D /* Authorizer.swift */; };
 		33A962771D89483600DA421E /* PusherConnectionDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A962751D8943CA00DA421E /* PusherConnectionDelegateTests.swift */; };
 		33BA541E1D90351B00CD853B /* NativePusherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA541D1D90351B00CD853B /* NativePusherTests.swift */; };
 		33BA54201D9035BD00CD853B /* PusherDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BA541F1D9035BD00CD853B /* PusherDelegate.swift */; };
@@ -65,6 +67,8 @@
 		3389F5711CAEDDF300563F49 /* PusherChannels.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PusherChannels.swift; sourceTree = "<group>"; };
 		3389F5751CAEDE2800563F49 /* PusherGlobalChannel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PusherGlobalChannel.swift; sourceTree = "<group>"; };
 		3389F5791CAEDEC800563F49 /* PusherClientOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PusherClientOptions.swift; sourceTree = "<group>"; };
+		3390D1E51F054D0400E1944D /* AuthRequestBuilderProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AuthRequestBuilderProtocol.swift; sourceTree = "<group>"; };
+		3390D1E71F054D1E00E1944D /* Authorizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Authorizer.swift; sourceTree = "<group>"; };
 		33A962751D8943CA00DA421E /* PusherConnectionDelegateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PusherConnectionDelegateTests.swift; path = ../Tests/PusherConnectionDelegateTests.swift; sourceTree = "<group>"; };
 		33BA541D1D90351B00CD853B /* NativePusherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NativePusherTests.swift; path = ../Tests/NativePusherTests.swift; sourceTree = "<group>"; };
 		33BA541F1D9035BD00CD853B /* PusherDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PusherDelegate.swift; sourceTree = "<group>"; };
@@ -135,6 +139,8 @@
 				3389F5711CAEDDF300563F49 /* PusherChannels.swift */,
 				3341A3391D819FBC007191AD /* NativePusher.swift */,
 				33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */,
+				3390D1E51F054D0400E1944D /* AuthRequestBuilderProtocol.swift */,
+				3390D1E71F054D1E00E1944D /* Authorizer.swift */,
 				33C0D2E71CB5C54C003FE13E /* Dependencies */,
 				33831CD61A9CFFF200B124F1 /* PusherSwift.h */,
 				33831C8C1A9CF61600B124F1 /* Supporting Files */,
@@ -329,6 +335,7 @@
 				33BA54201D9035BD00CD853B /* PusherDelegate.swift in Sources */,
 				3389F56A1CAEDD9100563F49 /* PusherWebsocketDelegate.swift in Sources */,
 				330D7A6D1CAEDA750032FF2C /* PusherChannel.swift in Sources */,
+				3390D1E81F054D1E00E1944D /* Authorizer.swift in Sources */,
 				3389F5721CAEDDF300563F49 /* PusherChannels.swift in Sources */,
 				3389F5761CAEDE2800563F49 /* PusherGlobalChannel.swift in Sources */,
 				3389F57A1CAEDEC800563F49 /* PusherClientOptions.swift in Sources */,
@@ -339,6 +346,7 @@
 				33C0D2D51CB5C1F2003FE13E /* CryptoSwiftHMACModule.swift in Sources */,
 				33C0D2DB1CB5C364003FE13E /* Starscream.swift in Sources */,
 				33C1FD6F1D81BFC300921AD7 /* ObjectiveC.swift in Sources */,
+				3390D1E61F054D0400E1944D /* AuthRequestBuilderProtocol.swift in Sources */,
 				330D7A6A1CAEDA6C0032FF2C /* PusherSwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ public class PusherAuth: NSObject {
 }
 ```
 
+Provided the authorization process succeeds you need to then call the supplied `completionHandler` with a `PusherAuth` object so that the subscription process can complete.
+
+If for whatever reason your authorization process fails then you just need to call the `completionHandler` with `nil` as the only parameter.
+
 Note that if you want to specify the cluster to which you want to connect then you use the `host` property as follows:
 
 #### Swift

--- a/README.md
+++ b/README.md
@@ -634,6 +634,24 @@ Note that both private and presence channels require the user to be authenticate
 We recommend that you use an authentication endpoint over including your app's secret in your app in the vast majority of use cases. If you are completely certain that there's no risk to you including your app's secret in your app, for example if your app is just for internal use at your company, then it can make things easier than setting up an authentication endpoint.
 
 
+### Subscribing with self-provided auth values
+
+It is possible to subscribe to channels that require authentication by providing the auth information at the point of calling `subscribe` or `subscribeToPresenceChannel`. This is done as shown below:
+
+#### Swift
+
+```swift
+let pusherAuth = PusherAuth(auth: yourAuthString, channelData: yourOptionalChannelDataString)
+let chan = self.pusher.subscribe(channelName, auth: pusherAuth)
+```
+
+This PusherAuth object can be initialised with just an auth (String) value if the subscription is to a private channel, or both an `auth (String)` and `channelData (String)` pair of values if the subscription is to a presence channel.
+
+These `auth` and `channelData` values are the values that you received if the json object created by a call to pusher.authenticate(...) in one of our various server libraries.
+
+Keep in mind that in order to generate a valid auth value for a subscription the `socketId` (i.e. the unique identifier for a web socket connection to the Pusher servers) must be present when the auth value is generated. As such, the likely flow for using this is something like this would involve checking for when the connection state becomes `connected` before trying to subscribe to any channels requiring authentication.
+
+
 ## Binding to events
 
 Events can be bound to at 2 levels; globally and per channel. When binding to an event you can choose to save the return value, which is a unique identifier for the event handler that gets created. The only reason to save this is if you're going to want to unbind from the event at a later point in time. There is an example of this below.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ public enum AuthMethod {
     case endpoint(authEndpoint: String)
     case authRequestBuilder(authRequestBuilder: AuthRequestBuilderProtocol)
     case inline(secret: String)
+    case authorizer(authorizer: Authorizer)
     case noMethod
 }
 ```
@@ -124,6 +125,7 @@ public enum AuthMethod {
 - `endpoint(authEndpoint: String)` - the client will make a `POST` request to the endpoint you specify with the socket ID of the client and the channel name attempting to be subscribed to
 - `authRequestBuilder(authRequestBuilder: AuthRequestBuilderProtocol)` - you specify an object that conforms to the `AuthRequestBuilderProtocol` (defined below), which must generate an `NSURLRequest` object that will be used to make the auth request
 - `inline(secret: String)` - your app's secret so that authentication requests do not need to be made to your authentication endpoint and instead subscriptions can be authenticated directly inside the library (this is mainly desgined to be used for development)
+- `authorizer(authorizer: Authorizer)` - you specify an object that conforms to the `Authorizer` protocol which must be able to provide the appropriate auth information
 - `noMethod` - if you are only using public channels then you do not need to set an `authMethod` (this is the default value)
 
 This is the `AuthRequestBuilderProtocol` definition:
@@ -134,6 +136,28 @@ public protocol AuthRequestBuilderProtocol {
 
     // DEPRECATED
     func requestFor(socketID: String, channel: PusherChannel) -> NSMutableURLRequest?
+}
+```
+
+This is the `Authorizer` protocol definition:
+
+```swift
+public protocol Authorizer {
+    func fetchAuthValue(socketID: String, channelName: String, completionHandler: (PusherAuth?) -> ())
+}
+```
+
+where `PusherAuth` is defined as:
+
+```swift
+public class PusherAuth: NSObject {
+    public let auth: String
+    public let channelData: String?
+
+    public init(auth: String, channelData: String? = nil) {
+        self.auth = auth
+        self.channelData = channelData
+    }
 }
 ```
 

--- a/Source/AuthRequestBuilderProtocol.swift
+++ b/Source/AuthRequestBuilderProtocol.swift
@@ -1,0 +1,9 @@
+//
+//  AuthRequestBuilderProtocol.swift
+//  PusherSwift
+//
+//  Created by Hamilton Chapman on 29/06/2017.
+//
+//
+
+import Foundation

--- a/Source/AuthRequestBuilderProtocol.swift
+++ b/Source/AuthRequestBuilderProtocol.swift
@@ -1,9 +1,8 @@
-//
-//  AuthRequestBuilderProtocol.swift
-//  PusherSwift
-//
-//  Created by Hamilton Chapman on 29/06/2017.
-//
-//
-
 import Foundation
+
+@objc public protocol AuthRequestBuilderProtocol {
+    @available(*, deprecated: 4.0.2, message: "use requestFor(socketID: String, channelName: String) -> URLRequest? instead")
+    @objc optional func requestFor(socketID: String, channel: PusherChannel) -> NSMutableURLRequest?
+
+    @objc optional func requestFor(socketID: String, channelName: String) -> URLRequest?
+}

--- a/Source/Authorizer.swift
+++ b/Source/Authorizer.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+@objc public protocol Authorizer {
+    @objc func fetchAuthValue(socketID: String, channelName: String, completionHandler: (PusherAuth?) -> ())
+}

--- a/Source/ObjectiveC.swift
+++ b/Source/ObjectiveC.swift
@@ -116,8 +116,10 @@ public extension AuthMethod {
             return OCAuthMethod(authRequestBuilder: authRequestBuilder)
         case let .inline(secret):
             return OCAuthMethod(secret: secret)
+        case let .authorizer(authorizer):
+            return OCAuthMethod(authorizer: authorizer)
         case .noMethod:
-            return OCAuthMethod(type: 3)
+            return OCAuthMethod(type: 4)
         }
     }
 
@@ -126,7 +128,8 @@ public extension AuthMethod {
         case 0: return AuthMethod.endpoint(authEndpoint: source.authEndpoint!)
         case 1: return AuthMethod.authRequestBuilder(authRequestBuilder: source.authRequestBuilder!)
         case 2: return AuthMethod.inline(secret: source.secret!)
-        case 3: return AuthMethod.noMethod
+        case 3: return AuthMethod.authorizer(authorizer: source.authorizer!)
+        case 4: return AuthMethod.noMethod
         default: return AuthMethod.noMethod
         }
     }
@@ -137,6 +140,7 @@ public extension AuthMethod {
     var secret: String? = nil
     var authEndpoint: String? = nil
     var authRequestBuilder: AuthRequestBuilderProtocol? = nil
+    var authorizer: Authorizer? = nil
 
     public init(type: Int) {
         self.type = type
@@ -155,5 +159,10 @@ public extension AuthMethod {
     public init(secret: String) {
         self.type = 2
         self.secret = secret
+    }
+
+    public init(authorizer: Authorizer) {
+        self.type = 3
+        self.authorizer = authorizer
     }
 }

--- a/Source/PusherClientOptions.swift
+++ b/Source/PusherClientOptions.swift
@@ -20,16 +20,10 @@ public enum PusherHost {
     }
 }
 
-@objc public protocol AuthRequestBuilderProtocol {
-    @available(*, deprecated: 4.0.2, message: "use requestFor(socketID: String, channelName: String) -> URLRequest? instead")
-    @objc optional func requestFor(socketID: String, channel: PusherChannel) -> NSMutableURLRequest?
-
-    @objc optional func requestFor(socketID: String, channelName: String) -> URLRequest?
-}
-
 public enum AuthMethod {
     case endpoint(authEndpoint: String)
     case authRequestBuilder(authRequestBuilder: AuthRequestBuilderProtocol)
+    case authorizer(authorizer: Authorizer)
     case inline(secret: String)
     case noMethod
 }

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -168,6 +168,22 @@ open class MockWebSocket: WebSocket {
                     self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"123\\\"],\\\"hash\\\":{\\\"123\\\":{\\\"friends\\\":0}}}}\",\"channel\":\"presence-channel\"}")
                 }
             )
+        } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:authorizerblah123", "private-test-channel-authorizer"]) {
+            let _ = stubber.stub(
+                functionName: "writeString",
+                args: [string],
+                functionToCall: {
+                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-test-channel-authorizer\",\"data\":\"{}\"}")
+                }
+            )
+        } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:authorizerblah1234", "presence-test-channel-authorizer"]) {
+            let _ = stubber.stub(
+                functionName: "writeString",
+                args: [string],
+                functionToCall: {
+                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"777\\\"],\\\"hash\\\":{\\\"777\\\":{\\\"twitter\\\":\\\"hamchapman\\\"}}}}\",\"channel\":\"presence-test-channel-authorizer\"}")
+                }
+            )
         } else {
             print("No match in write(string: ...) mock for string: \(string)")
         }


### PR DESCRIPTION
### Description of the pull request

Adds an `Authorizer` protocol that allows a more flexible setup for authenticating subscriptions to private and presence channels.

#### Why is the change necessary?

Adds a more flexible auth flow option

----

CC @pusher/mobile 