### PR TITLE
Unsubscribe all

### DIFF
--- a/Source/PusherConnection.swift
+++ b/Source/PusherConnection.swift
@@ -181,7 +181,7 @@ open class PusherConnection: NSObject {
     */
     internal func unsubscribeAll() {
         for (_, channel) in channels.channels {
-            pusher.unsubscribe(channel.name)
+            unsubscribe(channel.name)
         }
     }
 

--- a/Source/PusherSwift.swift
+++ b/Source/PusherSwift.swift
@@ -132,7 +132,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
     /**
         Unsubscribes the client from all channels
     */
-    open func unsubscribe(_ channelName: String) {
+    open func unsubscribeAll() {
         self.connection.unsubscribeAll()
     }
 

--- a/Source/PusherSwift.swift
+++ b/Source/PusherSwift.swift
@@ -128,6 +128,13 @@ let CLIENT_NAME = "pusher-websocket-swift"
     open func unsubscribe(_ channelName: String) {
         self.connection.unsubscribe(channelName: channelName)
     }
+    
+    /**
+        Unsubscribes the client from all channels
+    */
+    open func unsubscribe(_ channelName: String) {
+        self.connection.unsubscribeAll()
+    }
 
     /**
         Binds the client's global channel to all events


### PR DESCRIPTION
### Description of the pull request
Convenience method to unsubscribe from all channels at once.

### Why is the change necessary?

In a multi-user environment, on signing out, it is useful to unsubscribe from all channels.
In testing builds, its even more useful, as users have different ids across environments.

----

CC @pusher/mobile 
