### PR TITLE
Implement setSubscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/pusher/pusher-websocket-swift/compare/5.1.0...HEAD)
+
+## [5.1.0](https://github.com/pusher/pusher-websocket-swift/compare/5.0.1...5.1.0) - 2017-11-23
+## Added
+- [`setSubscriptions`](https://pusher.com/docs/push_notifications/reference/client_api#put-v1clientsclientidinterests) method.
 
 ## 5.0.1
 

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherSwift'
-  s.version          = '5.0.1'
+  s.version          = '5.1.0'
   s.summary          = 'A Pusher client library in Swift'
   s.homepage         = 'https://github.com/pusher/pusher-websocket-swift'
   s.license          = 'MIT'

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.1</string>
+	<string>5.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/NativePusher.swift
+++ b/Sources/NativePusher.swift
@@ -162,7 +162,14 @@ import Foundation
      - parameter interests: the name of the interests you want to subscribe to
      */
     open func setSubscriptions(interests: Array<String>) {
-        addSubscriptionChangeToTaskQueue(interests: interests, change: .setSubscriptions)
+        requestQueue.tasks += { _, next in
+            self.modifySubscription(
+                interests: interests,
+                successCallback: next
+            )
+        }
+        
+        requestQueue.run()
     }
 
     /**
@@ -188,17 +195,6 @@ import Foundation
             self.modifySubscription(
                 interest: interestName,
                 change: change,
-                successCallback: next
-            )
-        }
-
-        requestQueue.run()
-    }
-
-    private func addSubscriptionChangeToTaskQueue(interests: Array<String>, change: SubscriptionChange) {
-        requestQueue.tasks += { _, next in
-            self.modifySubscription(
-                interests: interests,
                 successCallback: next
             )
         }

--- a/Sources/NativePusher.swift
+++ b/Sources/NativePusher.swift
@@ -227,7 +227,6 @@ import Foundation
     /**
      Makes a PUT request for given interests
      - parameter interests:    The name of the interests to be subscribed to
-     - parameter change:       Whether to subscribe or unsubscribe
      - parameter callback:     Callback to be called upon success
      */
     private func modifySubscription(interests: Array<String>, successCallback: @escaping (Any?) -> Void) {

--- a/Sources/NativePusher.swift
+++ b/Sources/NativePusher.swift
@@ -199,7 +199,6 @@ import Foundation
         requestQueue.tasks += { _, next in
             self.modifySubscription(
                 interests: interests,
-                change: change,
                 successCallback: next
             )
         }
@@ -235,7 +234,7 @@ import Foundation
      - parameter change:       Whether to subscribe or unsubscribe
      - parameter callback:     Callback to be called upon success
      */
-    private func modifySubscription(interests: Array<String>, change: SubscriptionChange, successCallback: @escaping (Any?) -> Void) {
+    private func modifySubscription(interests: Array<String>, successCallback: @escaping (Any?) -> Void) {
         guard
             let clientId = clientId,
             let pusherAppKey = pusherAppKey
@@ -247,8 +246,8 @@ import Foundation
 
         let url = "\(CLIENT_API_V1_ENDPOINT)/clients/\(clientId)/interests/"
         let params: [String: Any] = ["app_key": pusherAppKey, "interests": interests]
-        let request = self.setRequest(url: url, params: params, change: change)
-        self.modifySubscription(interests: interests, request: request, change: change, successCallback: successCallback)
+        let request = self.setRequest(url: url, params: params, change: .setSubscriptions)
+        self.modifySubscription(interests: interests, request: request, change: .setSubscriptions, successCallback: successCallback)
     }
 
     private func modifySubscription(interests: Array<String>, request: URLRequest, change: SubscriptionChange, successCallback: @escaping (Any?) -> Void) {

--- a/Sources/NativePusher.swift
+++ b/Sources/NativePusher.swift
@@ -289,7 +289,7 @@ import Foundation
                     self.delegate?.unsubscribedFromInterest?(name: interest)
                 }
 
-                self.delegate?.debugLog?(message: "Success making \(change.stringValue) to \(interests)")
+                self.delegate?.debugLog?(message: "Success making \(change.rawValue) to \(interests)")
 
                 self.failedRequestAttempts = 0
                 successCallback(nil)
@@ -312,21 +312,10 @@ import Foundation
     }
 }
 
-internal enum SubscriptionChange {
+internal enum SubscriptionChange: String {
     case subscribe
     case setSubscriptions
     case unsubscribe
-
-    internal func stringValue() -> String {
-        switch self {
-        case .subscribe:
-            return "subscribe"
-        case .setSubscriptions:
-            return "setSubscriptions"
-        case .unsubscribe:
-            return "unsubscribe"
-        }
-    }
 
     internal func httpMethod() -> String {
         switch self {

--- a/Sources/PusherDelegate.swift
+++ b/Sources/PusherDelegate.swift
@@ -12,6 +12,7 @@
     @objc optional func registeredForPushNotifications(clientId: String)
     @objc optional func failedToRegisterForPushNotifications(response: URLResponse, responseBody: String?)
     @objc optional func subscribedToInterest(name: String)
+    @objc optional func subscribedToInterests(interests: Array<String>)
     @objc optional func unsubscribedFromInterest(name: String)
 
     @objc optional func changedConnectionState(from old: ConnectionState, to new: ConnectionState)

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 let PROTOCOL = 7
-let VERSION = "5.0.1"
+let VERSION = "5.1.0"
 let CLIENT_NAME = "pusher-websocket-swift"
 
 @objcMembers

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.0.1</string>
+	<string>5.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/PusherClientInitializationTests.swift
+++ b/Tests/PusherClientInitializationTests.swift
@@ -9,7 +9,7 @@
 import PusherSwift
 import XCTest
 
-let VERSION = "5.0.1"
+let VERSION = "5.1.0"
 
 class ClientInitializationTests: XCTestCase {
     var key: String!


### PR DESCRIPTION
### Description of the pull request

Users can now subscribe the client to all interests in the provided set as it is described [here](https://pusher.com/docs/push_notifications/reference/client_api#put-v1clientsclientidinterests).

#### Why is the change necessary?

To add additional functionality in the SDK.

----

CC @pusher/mobile 