### PR TITLE
Made Authorizer completion handler @escaping

### DIFF
--- a/Sources/Authorizer.swift
+++ b/Sources/Authorizer.swift
@@ -1,5 +1,6 @@
 import Foundation
 
 @objc public protocol Authorizer {
-    @objc func fetchAuthValue(socketID: String, channelName: String, completionHandler: (PusherAuth?) -> ())
+    @objc func fetchAuthValue(socketID: String, channelName: String,
+    completionHandler: @escaping (PusherAuth?) -> ())
 }

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -604,7 +604,7 @@ public typealias PusherEventJSON = [String: AnyObject]
                         return
                     }
 
-                    handleAuthInfo(authString: authInfo.auth, channelData: authInfo.channelData, channel: channel)
+                    self.handleAuthInfo(authString: authInfo.auth, channelData: authInfo.channelData, channel: channel)
                 }
 
                 return true

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -250,7 +250,7 @@ class AuthenticationTests: XCTestCase {
     func testAuthorizationUsingSomethingConformingToTheAuthorizerProtocol() {
 
         class SomeAuthorizer: Authorizer {
-            func fetchAuthValue(socketID: String, channelName: String, completionHandler: (PusherAuth?) -> ()) {
+            func fetchAuthValue(socketID: String, channelName: String, completionHandler: @escaping (PusherAuth?) -> ()) {
                 completionHandler(PusherAuth(auth: "testKey123:authorizerblah123"))
             }
         }
@@ -280,7 +280,7 @@ class AuthenticationTests: XCTestCase {
     func testAuthorizationOfPresenceChannelSubscriptionUsingSomethingConformingToTheAuthorizerProtocol() {
 
         class SomeAuthorizer: Authorizer {
-            func fetchAuthValue(socketID: String, channelName: String, completionHandler: (PusherAuth?) -> ()) {
+            func fetchAuthValue(socketID: String, channelName: String, completionHandler: @escaping (PusherAuth?) -> ()) {
                 completionHandler(PusherAuth(
                     auth: "testKey123:authorizerblah1234",
                     channelData: "{\"user_id\":\"777\", \"user_info\":{\"twitter\":\"hamchapman\"}}"


### PR DESCRIPTION
### Description of the pull request

Add `@escaping` to the parameter for the `Authorizer` protocol.

#### Why is the change necessary?

To allow the completion handler to be called from within a closure.

----

CC @pusher/mobile 
