### PR TITLE
Capture self reference before using self reference in Reachability closures

### DIFF
--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -42,14 +42,14 @@ public typealias PusherEventJSON = [String: AnyObject]
     open lazy var reachability: Reachability? = {
         let reachability = Reachability.init()
         reachability?.whenReachable = { [weak self] reachability in
-            guard self != nil else {
+            guard let _self = self else {
                 print("Your Pusher instance has probably become deallocated. See https://github.com/pusher/pusher-websocket-swift/issues/109 for more information")
                 return
             }
 
-            self!.delegate?.debugLog?(message: "[PUSHER DEBUG] Network reachable")
+            _self.delegate?.debugLog?(message: "[PUSHER DEBUG] Network reachable")
 
-            switch self!.connectionState {
+            switch _self.connectionState {
             case .disconnecting, .connecting, .reconnecting:
                 // If in one of these states then part of the connection, reconnection, or explicit
                 // disconnection process is underway, so do nothing
@@ -57,27 +57,27 @@ public typealias PusherEventJSON = [String: AnyObject]
             case .disconnected:
                 // If already disconnected then reset connection and try to reconnect, provided the
                 // state isn't disconnected because of an intentional disconnection
-                if !self!.intentionalDisconnect { self!.resetConnectionAndAttemptReconnect() }
+                if !_self.intentionalDisconnect { _self.resetConnectionAndAttemptReconnect() }
                 return
             case .connected:
                 // If already connected then we assume that there was a missed network event that
                 // led to a bad connection so we move to the disconnected state and then attempt
                 // reconnection
-                self!.delegate?.debugLog?(
+                _self.delegate?.debugLog?(
                     message: "[PUSHER DEBUG] Connection state is \(self!.connectionState.stringValue()) but received network reachability change so going to call attemptReconnect"
                 )
-                self!.resetConnectionAndAttemptReconnect()
+                _self.resetConnectionAndAttemptReconnect()
                 return
             }
         }
         reachability?.whenUnreachable = { [weak self] reachability in
-            guard self != nil else {
+            guard let _self = self else {
                 print("Your Pusher instance has probably become deallocated. See https://github.com/pusher/pusher-websocket-swift/issues/109 for more information")
                 return
             }
 
-            self!.delegate?.debugLog?(message: "[PUSHER DEBUG] Network unreachable")
-            self!.resetConnectionAndAttemptReconnect()
+            _self.delegate?.debugLog?(message: "[PUSHER DEBUG] Network unreachable")
+            _self.resetConnectionAndAttemptReconnect()
         }
         return reachability
     }()

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -42,14 +42,14 @@ public typealias PusherEventJSON = [String: AnyObject]
     open lazy var reachability: Reachability? = {
         let reachability = Reachability.init()
         reachability?.whenReachable = { [weak self] reachability in
-            guard let _self = self else {
+            guard let strongSelf = self else {
                 print("Your Pusher instance has probably become deallocated. See https://github.com/pusher/pusher-websocket-swift/issues/109 for more information")
                 return
             }
 
-            _self.delegate?.debugLog?(message: "[PUSHER DEBUG] Network reachable")
+            strongSelf.delegate?.debugLog?(message: "[PUSHER DEBUG] Network reachable")
 
-            switch _self.connectionState {
+            switch strongSelf.connectionState {
             case .disconnecting, .connecting, .reconnecting:
                 // If in one of these states then part of the connection, reconnection, or explicit
                 // disconnection process is underway, so do nothing
@@ -57,27 +57,27 @@ public typealias PusherEventJSON = [String: AnyObject]
             case .disconnected:
                 // If already disconnected then reset connection and try to reconnect, provided the
                 // state isn't disconnected because of an intentional disconnection
-                if !_self.intentionalDisconnect { _self.resetConnectionAndAttemptReconnect() }
+                if !strongSelf.intentionalDisconnect { strongSelf.resetConnectionAndAttemptReconnect() }
                 return
             case .connected:
                 // If already connected then we assume that there was a missed network event that
                 // led to a bad connection so we move to the disconnected state and then attempt
                 // reconnection
-                _self.delegate?.debugLog?(
+                strongSelf.delegate?.debugLog?(
                     message: "[PUSHER DEBUG] Connection state is \(self!.connectionState.stringValue()) but received network reachability change so going to call attemptReconnect"
                 )
-                _self.resetConnectionAndAttemptReconnect()
+                strongSelf.resetConnectionAndAttemptReconnect()
                 return
             }
         }
         reachability?.whenUnreachable = { [weak self] reachability in
-            guard let _self = self else {
+            guard let strongSelf = self else {
                 print("Your Pusher instance has probably become deallocated. See https://github.com/pusher/pusher-websocket-swift/issues/109 for more information")
                 return
             }
 
-            _self.delegate?.debugLog?(message: "[PUSHER DEBUG] Network unreachable")
-            _self.resetConnectionAndAttemptReconnect()
+            strongSelf.delegate?.debugLog?(message: "[PUSHER DEBUG] Network unreachable")
+            strongSelf.resetConnectionAndAttemptReconnect()
         }
         return reachability
     }()


### PR DESCRIPTION
#### Why is the change necessary?

Implicitly unwrapping `self` is not safe. Checking that `self` is not `nil` is not safe enough to implicitly unwrap `self` later in a function. The only way to make sure `self` is not `nil` is to create a strong reference to `self` before using it.

We are seeing the code crash in our app when the pusher connection is released and the reachability is checked at the same time.