### PR TITLE
Allow Newer Dependency Versions

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ashleymills/Reachability.swift" "v4.1.0"
-github "daltoniam/Starscream" "3.0.5"
+github "ashleymills/Reachability.swift" "v4.3.0"
+github "daltoniam/Starscream" "3.0.6"
 github "icanzilb/TaskQueue" "1.1.1"
-github "krzyzanowskim/CryptoSwift" "0.9.0"
+github "krzyzanowskim/CryptoSwift" "0.13.1"

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -11,10 +11,10 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'Sources/*.swift'
 
-  s.dependency 'CryptoSwift', '~> 0.9.0'
-  s.dependency 'ReachabilitySwift', '~> 4.1.0'
-  s.dependency 'TaskQueue', '~> 1.1.1'
-  s.dependency 'Starscream', '~> 3.0.5'
+  s.dependency 'CryptoSwift', '~> 0.9'
+  s.dependency 'ReachabilitySwift', '~> 4.1'
+  s.dependency 'TaskQueue', '~> 1.1'
+  s.dependency 'Starscream', '~> 3.0'
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
### Description of the pull request

This PR relaxes the pinned versions of PusherSwift's dependencies.

#### Why is the change necessary?

My project is currently unable to update to update CryptoSwift beyond version 0.9.0 and ReachabilitySwift beyond 4.1.0. This is preventing the project from enjoying new features in these libraries such as Swift 4.2 compatibility and bug fixes, to name a few.

I've compiled and run PusherSwift with these changes and I can see no compatibility issues which would prevent this from being a desirable change to make.