### PR TITLE
`let` properties are implicitly `final`, so the `open` modifier is me…

### DIFF
--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -28,10 +28,10 @@ public enum PusherChannelType {
 open class PusherChannel: NSObject {
     open var eventHandlers: [String: [EventHandler]] = [:]
     open var subscribed = false
-    open let name: String
+    public let name: String
     open weak var connection: PusherConnection?
     open var unsentEvents = [PusherEvent]()
-    open let type: PusherChannelType
+    public let type: PusherChannelType
     public var auth: PusherAuth?
 
     /**

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -7,8 +7,8 @@ public typealias PusherEventJSON = [String: AnyObject]
 
 @objcMembers
 @objc open class PusherConnection: NSObject {
-    open let url: String
-    open let key: String
+    public let url: String
+    public let key: String
     open var options: PusherClientOptions
     open var globalChannel: GlobalChannel!
     open var socketId: String?


### PR DESCRIPTION
…aningless.  Change them to `public` in order to avoid a warning from the compiler

### Description of the pull request

Change `let` properties to `public` instead of `open`

#### Why is the change necessary?

Eliminate build warnings in Xcode 10 and later