### PR TITLE
Fix unreliable tests

### DIFF
--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -153,7 +153,8 @@ open class MockWebSocket: WebSocket {
                 args: [string],
                 functionToCall: nil
             )
-        } else if stringContainsElements(string, elements: ["testkey123:736f0b19c2e56f985f3e6faa38db5b69d39305bc8519952c8f9f5595d69fcb3d", "presence-test", "user_id", "123", "pusher:subscribe", "user_info", "twitter", "hamchapman"]) {
+        } else if stringContainsElements(string, elements: ["presence-test", "user_id", "123", "pusher:subscribe", "user_info", "twitter", "hamchapman"]) && (stringContainsElements(string, elements: ["testkey123:736f0b19c2e56f985f3e6faa38db5b69d39305bc8519952c8f9f5595d69fcb3d"]) || stringContainsElements(string, elements: ["testkey123:e5ee520a16348ced21be557e14ae70fcd1ae89f79d32d14d22a19049eaf56881"])) {
+            // We require different auth signatures depending on the ordering of the channel_data JSON/Dictionary
             let _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
@@ -169,7 +170,8 @@ open class MockWebSocket: WebSocket {
                     self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"123\\\"],\\\"hash\\\":{\\\"123\\\":{}}}}\",\"channel\":\"presence-channel\"}")
                 }
             )
-        } else if stringContainsElements(string, elements: ["pusher:subscribe", "key:dd2885ee6dc6f5c964d8e3c720980397db50bf8f528e0630d4208bff80ee23f0", "presence-channel", "friends", "0", "user_id", "123"]) {
+        } else if stringContainsElements(string, elements: ["pusher:subscribe", "presence-channel", "friends", "0", "user_id", "123"]) && (stringContainsElements(string, elements: ["key:dd2885ee6dc6f5c964d8e3c720980397db50bf8f528e0630d4208bff80ee23f0"]) || stringContainsElements(string, elements: ["key:80cfefb0ef08fb55353dbbc0480e6160059fac14fce862e9ed1f0121ae8a440f"])) {
+            // We require different auth signatures depending on the ordering of the channel_data JSON/Dictionary
             let _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],

--- a/Tests/PusherTopLevelAPITests.swift
+++ b/Tests/PusherTopLevelAPITests.swift
@@ -241,13 +241,14 @@ class PusherTopLevelApiTests: XCTestCase {
             let unsubscribedFromChannel = socket.stubber.calls.contains { call in
                 guard
                     call.name == "writeString",
-                    let firstArg = call.args?.first
+                    let arguments = call.args,
+                    let firstArg = arguments.first,
+                    let stringFirstArg = firstArg as? String,
+                    let parsedCallArgs = convertStringToDictionary(stringFirstArg)
                 else {
                     return false
                 }
-
-                let parsedCallArgs = convertStringToDictionary(firstArg as! String)
-                return NSDictionary(dictionary: parsedCallArgs!).isEqual(to: NSDictionary(dictionary: expectedCallArguments) as [NSObject: AnyObject])
+                return NSDictionary(dictionary: parsedCallArgs).isEqual(to: NSDictionary(dictionary: expectedCallArguments) as [NSObject: AnyObject])
             }
             XCTAssertTrue(unsubscribedFromChannel, "should have unsubscribed from \(channel)")
         }


### PR DESCRIPTION
This PR fixes a number of unreliable tests that sometimes fail (but not consistently). Each of the tests depend on the order of a dictionary. Dictionaries are unordered and their orders are unpredictable,  leading to inconsistent test results.

In the case of `testUnsubscribingFromAllChannelsRemovesTheChannels`, the test depended on `test-channel2` being unsubscribed from last. However, the order in which the channels are unsubscribed from depends on the order of the channels dictionary, which is unpredictable. The test was fixed by checking that unsubscribe messages were sent for both channels, ignoring the order.

In the case of `testFindingTheClientsMemberObject`, `testFindingAPresenceChannelAsAPusherPresenceChannel` and `testMembersObjectStoresUserIdAndUserInfoIfAUserDataFetcherIsProvidedThatReturnsBoth`, the auth signature depends on the order of the keys in the channel_data JSON. The order of the keys in the channel_data JSON depends on the order of the dictionary from which it is generated, which is unpredictable. These tests are fixed by adding extra auth signatures for the other possible orderings. It may be beneficial to modify the mocks to verify the auth signatures, rather than hardcode them, but that is a more significant change and could be considered for future work.
