### PR TITLE
Fix error caused by multiple 'fulfill' calls on expectations

### DIFF
--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -20,7 +20,8 @@ class AuthenticationTests: XCTestCase {
         super.setUp()
 
         let options = PusherClientOptions(
-            authMethod: AuthMethod.endpoint(authEndpoint: "http://localhost:9292/pusher/auth")
+            authMethod: AuthMethod.endpoint(authEndpoint: "http://localhost:9292/pusher/auth"),
+            autoReconnect: false
         )
         pusher = Pusher(key: "testKey123", options: options)
         socket = MockWebSocket()
@@ -76,7 +77,8 @@ class AuthenticationTests: XCTestCase {
 
     func testSubscribingToAPrivateChannelShouldCreateAuthSignatureInternally() {
         let options = PusherClientOptions(
-            authMethod: .inline(secret: "secret")
+            authMethod: .inline(secret: "secret"),
+            autoReconnect: false
         )
         pusher = Pusher(key: "key", options: options)
         socket.delegate = pusher.connection
@@ -89,7 +91,10 @@ class AuthenticationTests: XCTestCase {
     }
 
     func testSubscribingToAPrivateChannelShouldFailIfNoAuthMethodIsProvided() {
-        pusher = Pusher(key: "key")
+        let options = PusherClientOptions(
+            autoReconnect: false
+        )
+        pusher = Pusher(key: "key", options: options)
         socket.delegate = pusher.connection
         pusher.connection.socket = socket
 
@@ -143,7 +148,8 @@ class AuthenticationTests: XCTestCase {
         dummyDelegate.testingChannelName = channelName
 
         let options = PusherClientOptions(
-            authMethod: AuthMethod.authRequestBuilder(authRequestBuilder: AuthRequestBuilder())
+            authMethod: AuthMethod.authRequestBuilder(authRequestBuilder: AuthRequestBuilder()),
+            autoReconnect: false
         )
         pusher = Pusher(key: "testKey123", options: options)
         pusher.delegate = dummyDelegate
@@ -216,7 +222,8 @@ class AuthenticationTests: XCTestCase {
         dummyDelegate.testingChannelName = channelName
 
         let options = PusherClientOptions(
-            authMethod: AuthMethod.authorizer(authorizer: SomeAuthorizer())
+            authMethod: AuthMethod.authorizer(authorizer: SomeAuthorizer()),
+            autoReconnect: false
         )
         pusher = Pusher(key: "testKey123", options: options)
         pusher.delegate = dummyDelegate
@@ -249,7 +256,8 @@ class AuthenticationTests: XCTestCase {
         dummyDelegate.testingChannelName = channelName
 
         let options = PusherClientOptions(
-            authMethod: AuthMethod.authorizer(authorizer: SomeAuthorizer())
+            authMethod: AuthMethod.authorizer(authorizer: SomeAuthorizer()),
+            autoReconnect: false
         )
         pusher = Pusher(key: "testKey123", options: options)
         pusher.delegate = dummyDelegate

--- a/Tests/ClientEventTests.swift
+++ b/Tests/ClientEventTests.swift
@@ -9,7 +9,11 @@ class ClientEventTests: XCTestCase {
         super.setUp()
 
         socket = MockWebSocket()
-        connection = MockPusherConnection(options: PusherClientOptions(authMethod: .inline(secret: "superSecretSecret")))
+        let options = PusherClientOptions(
+            authMethod: .inline(secret: "superSecretSecret"),
+            autoReconnect: false
+        )
+        connection = MockPusherConnection(options: options)
         socket.delegate = connection
         connection.socket = socket
     }

--- a/Tests/PresenceChannelTests.swift
+++ b/Tests/PresenceChannelTests.swift
@@ -11,7 +11,8 @@ class PusherPresenceChannelTests: XCTestCase {
         super.setUp()
 
         options = PusherClientOptions(
-            authMethod: .inline(secret: "secret")
+            authMethod: .inline(secret: "secret"),
+            autoReconnect: false
         )
         pusher = Pusher(key: "key", options: options)
         socket = MockWebSocket()
@@ -119,7 +120,8 @@ class PusherPresenceChannelTests: XCTestCase {
 
     func testOnMemberAddedFunctionGetsCalledWhenANewSubscriptionSucceeds() {
         let options = PusherClientOptions(
-            authMethod: .inline(secret: "secretsecretsecretsecret")
+            authMethod: .inline(secret: "secretsecretsecretsecret"),
+            autoReconnect: false
         )
         pusher = Pusher(key: "key", options: options)
         socket.delegate = pusher.connection
@@ -138,7 +140,8 @@ class PusherPresenceChannelTests: XCTestCase {
 
     func testOnMemberRemovedFunctionGetsCalledWhenANewSubscriptionSucceeds() {
         let options = PusherClientOptions(
-            authMethod: .inline(secret: "secretsecretsecretsecret")
+            authMethod: .inline(secret: "secretsecretsecretsecret"),
+            autoReconnect: false
         )
         pusher = Pusher(key: "key", options: options)
         socket.delegate = pusher.connection
@@ -159,7 +162,8 @@ class PusherPresenceChannelTests: XCTestCase {
 
     func testOnMemberRemovedFunctionGetsCalledWhenANewSubscriptionSucceedsIfTheMemberUserIdWasNotAStringOriginally() {
         let options = PusherClientOptions(
-            authMethod: .inline(secret: "secretsecretsecretsecret")
+            authMethod: .inline(secret: "secretsecretsecretsecret"),
+            autoReconnect: false
         )
         pusher = Pusher(key: "key", options: options)
         socket.delegate = pusher.connection


### PR DESCRIPTION
Reachability was calling the 'whenReachable' callback straight after connecting, which led to reconnection attempts. Those reconnections caused certain tests to throw exceptions because 'fulfill' was called multiple times on expectations. E.g.:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'API violation - multiple calls made to -[XCTestExpectation fulfill] for the channel should be subscribed to successfully.'
```

This PR disables autoReconnect for tests where 'connect' is called, so that Reachability isn't activated. These tests aren't specifically testing the reconnection behaviour or the behaviour of Reachability. Having those features enabled makes the tests less reliable and makes the tests dependent on network connectivity. The reconnection logic should be tested in separate tests.