### PR TITLE
Use carthage boostrap rather than update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
       brew install carthage;
     fi
   - gem install xcpretty --no-document
-  - carthage update --no-use-binaries
+  - carthage bootstrap --no-use-binaries
   - SIMULATOR_ID=$(xcrun instruments -s | grep -o "$DEVICE \[.*\]" | grep -o "\[.*\]" | sed "s/^\[\(.*\)\]$/\1/")
   - echo "$SIMULATOR_ID"
 before_deploy:


### PR DESCRIPTION
### Description of the pull request
Modifies the Travis config to use `bootstrap` rather than `update`.
...

#### Why is the change necessary?
`update` pulls in the latest version of the dependencies, which aren't compatible with our current Swift version and Travis Xcode version. These will be updated, but it makes sense to use `bootstrap` instead, which will use the dependency versions as specified in `Cartfile.resolved`.
...
