### PR TITLE
Defining versions in Cartfile for dependencies 

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "krzyzanowskim/CryptoSwift"
-github "ashleymills/Reachability.swift"
-github "icanzilb/TaskQueue"
-github "daltoniam/Starscream"
+github "krzyzanowskim/CryptoSwift" ~> 0.15
+github "ashleymills/Reachability.swift" == 4.3.0
+github "icanzilb/TaskQueue" ~> 1.0.3
+github "daltoniam/Starscream" == 3.0.6

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "krzyzanowskim/CryptoSwift" ~> 0.15
+github "krzyzanowskim/CryptoSwift" == 0.15.0
 github "ashleymills/Reachability.swift" == 4.3.0
-github "icanzilb/TaskQueue" ~> 1.0.3
+github "icanzilb/TaskQueue" == 1.1.1
 github "daltoniam/Starscream" == 3.0.6

--- a/Cartfile
+++ b/Cartfile
@@ -1,4 +1,4 @@
-github "krzyzanowskim/CryptoSwift" == 0.15.0
+github "krzyzanowskim/CryptoSwift" ~> 0.15.0
 github "ashleymills/Reachability.swift" == 4.3.0
-github "icanzilb/TaskQueue" == 1.1.1
+github "icanzilb/TaskQueue" ~> 1.1.1
 github "daltoniam/Starscream" == 3.0.6

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "ashleymills/Reachability.swift" "v4.1.0"
-github "daltoniam/Starscream" "3.0.5"
+github "ashleymills/Reachability.swift" "v4.3.0"
+github "daltoniam/Starscream" "3.0.6"
 github "icanzilb/TaskQueue" "1.1.1"
-github "krzyzanowskim/CryptoSwift" "0.9.0"
+github "krzyzanowskim/CryptoSwift" "0.15.0"

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.dependency 'CryptoSwift', '~> 0.9'
   s.dependency 'ReachabilitySwift', '4.3.0'
   s.dependency 'TaskQueue', '~> 1.1'
-  s.dependency 'Starscream', '3.0.6'
+  s.dependency 'Starscream', '~> 3.0.5'
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -11,9 +11,9 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'Sources/*.swift'
 
-  s.dependency 'CryptoSwift', '0.15.0'
+  s.dependency 'CryptoSwift', '~> 0.9'
   s.dependency 'ReachabilitySwift', '4.3.0'
-  s.dependency 'TaskQueue', '1.1.1'
+  s.dependency 'TaskQueue', '~> 1.1'
   s.dependency 'Starscream', '3.0.6'
 
   s.ios.deployment_target = '8.0'

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -11,10 +11,10 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.source_files = 'Sources/*.swift'
 
-  s.dependency 'CryptoSwift', '~> 0.9.0'
-  s.dependency 'ReachabilitySwift', '~> 4.1.0'
-  s.dependency 'TaskQueue', '~> 1.1.1'
-  s.dependency 'Starscream', '~> 3.0.5'
+  s.dependency 'CryptoSwift', '0.15.0'
+  s.dependency 'ReachabilitySwift', '4.3.0'
+  s.dependency 'TaskQueue', '1.1.1'
+  s.dependency 'Starscream', '3.0.6'
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'


### PR DESCRIPTION
### Description of the pull request
Defining versions in Cartfile for dependencies so dependencies can update to latest xcode/swift and publish breaking versions without breaking current release of this when still run on something other than the latest xcode/swift development environment

#### Why is the change necessary?
Reachability, Starscream, and CryptoSwift have all published releases compatible with Swift 5 and XCode 10.2.   Because the current Cartfile does not define any version requirements for the depencies, the "latest" release is always taken.    Running `carthage update` or `carthage bootstrap` as our CI build tool does is now failing as we are not yet running XCode 10.2 in CI (or locally).   

Going forward, as releases of this library come out supporting different swift/xcode versions, the versions of the dependencies should remain defined (and updated) in the Cartfile so that they build with the correct known working versions. 

