### PR TITLE
Update to Swift 4.2

### DIFF
--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -8,8 +8,9 @@ Pod::Spec.new do |s|
   s.source           = { git: "https://github.com/pusher/pusher-websocket-swift.git", tag: s.version.to_s }
   s.social_media_url = 'https://twitter.com/pusher'
 
-  s.requires_arc = true
-  s.source_files = 'Sources/*.swift'
+  s.swift_version = '4.2'
+  s.requires_arc  = true
+  s.source_files  = 'Sources/*.swift'
 
   s.dependency 'CryptoSwift', '~> 0.9'
   s.dependency 'ReachabilitySwift', '4.3.0'

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -246,11 +246,11 @@
 				TargetAttributes = {
 					33831C881A9CF61600B124F1 = {
 						CreatedOnToolsVersion = 6.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1010;
 					};
 					33831C931A9CF61600B124F1 = {
 						CreatedOnToolsVersion = 6.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -498,7 +498,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -555,7 +555,7 @@
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -613,7 +613,7 @@
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
@@ -659,7 +659,7 @@
 				PRODUCT_NAME = PusherSwiftTests;
 				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 			};

--- a/Sources/ObjectiveC.swift
+++ b/Sources/ObjectiveC.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 @objc public extension Pusher {
-    public func subscribe(channelName: String) -> PusherChannel {
+    func subscribe(channelName: String) -> PusherChannel {
         return self.subscribe(channelName, onMemberAdded: nil, onMemberRemoved: nil)
     }
 
-    public func subscribe(
+    func subscribe(
         channelName: String,
         onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
@@ -13,11 +13,11 @@ import Foundation
         return self.subscribe(channelName, auth: nil, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
     }
 
-    public func subscribeToPresenceChannel(channelName: String) -> PusherPresenceChannel {
+    func subscribeToPresenceChannel(channelName: String) -> PusherPresenceChannel {
         return self.subscribeToPresenceChannel(channelName: channelName, auth: nil, onMemberAdded: nil, onMemberRemoved: nil)
     }
 
-    public func subscribeToPresenceChannel(
+    func subscribeToPresenceChannel(
         channelName: String,
         onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
@@ -25,17 +25,17 @@ import Foundation
         return self.subscribeToPresenceChannel(channelName: channelName, auth: nil, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
     }
 
-    public convenience init(withAppKey key: String, options: PusherClientOptions) {
+    convenience init(withAppKey key: String, options: PusherClientOptions) {
         self.init(key: key, options: options)
     }
 
-    public convenience init(withKey key: String) {
+    convenience init(withKey key: String) {
         self.init(key: key)
     }
 }
 
 @objc public extension PusherConnection {
-    public var OCReconnectAttemptsMax: NSNumber? {
+    var OCReconnectAttemptsMax: NSNumber? {
         get {
             return reconnectAttemptsMax as NSNumber?
         }
@@ -44,7 +44,7 @@ import Foundation
         }
     }
 
-    public var OCMaxReconnectGapInSeconds: NSNumber? {
+    var OCMaxReconnectGapInSeconds: NSNumber? {
         get {
             return maxReconnectGapInSeconds as NSNumber?
         }
@@ -55,7 +55,7 @@ import Foundation
 }
 
 @objc public extension PusherClientOptions {
-    public convenience init(
+    convenience init(
         ocAuthMethod authMethod: OCAuthMethod,
         attemptToReturnJSONObject: Bool = true,
         autoReconnect: Bool = true,
@@ -75,11 +75,11 @@ import Foundation
         )
     }
 
-    public convenience init(authMethod: OCAuthMethod) {
+    convenience init(authMethod: OCAuthMethod) {
         self.init(authMethod: AuthMethod.fromObjc(source: authMethod))
     }
 
-    public func setAuthMethod(authMethod: OCAuthMethod) {
+    func setAuthMethod(authMethod: OCAuthMethod) {
         self.authMethod = AuthMethod.fromObjc(source: authMethod)
     }
 }

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -28,10 +28,10 @@ public enum PusherChannelType {
 open class PusherChannel: NSObject {
     open var eventHandlers: [String: [EventHandler]] = [:]
     open var subscribed = false
-    open let name: String
+    public let name: String
     open weak var connection: PusherConnection?
     open var unsentEvents = [PusherEvent]()
-    open let type: PusherChannelType
+    public let type: PusherChannelType
     public var auth: PusherAuth?
 
     /**

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -42,14 +42,14 @@ public typealias PusherEventJSON = [String: AnyObject]
     open lazy var reachability: Reachability? = {
         let reachability = Reachability.init()
         reachability?.whenReachable = { [weak self] reachability in
-            guard let strongSelf = self else {
+            guard let self = self else {
                 print("Your Pusher instance has probably become deallocated. See https://github.com/pusher/pusher-websocket-swift/issues/109 for more information")
                 return
             }
 
-            strongSelf.delegate?.debugLog?(message: "[PUSHER DEBUG] Network reachable")
+            self.delegate?.debugLog?(message: "[PUSHER DEBUG] Network reachable")
 
-            switch strongSelf.connectionState {
+            switch self.connectionState {
             case .disconnecting, .connecting, .reconnecting:
                 // If in one of these states then part of the connection, reconnection, or explicit
                 // disconnection process is underway, so do nothing
@@ -57,27 +57,27 @@ public typealias PusherEventJSON = [String: AnyObject]
             case .disconnected:
                 // If already disconnected then reset connection and try to reconnect, provided the
                 // state isn't disconnected because of an intentional disconnection
-                if !strongSelf.intentionalDisconnect { strongSelf.resetConnectionAndAttemptReconnect() }
+                if !self.intentionalDisconnect { self.resetConnectionAndAttemptReconnect() }
                 return
             case .connected:
                 // If already connected then we assume that there was a missed network event that
                 // led to a bad connection so we move to the disconnected state and then attempt
                 // reconnection
-                strongSelf.delegate?.debugLog?(
-                    message: "[PUSHER DEBUG] Connection state is \(self!.connectionState.stringValue()) but received network reachability change so going to call attemptReconnect"
+                self.delegate?.debugLog?(
+                    message: "[PUSHER DEBUG] Connection state is \(self.connectionState.stringValue()) but received network reachability change so going to call attemptReconnect"
                 )
-                strongSelf.resetConnectionAndAttemptReconnect()
+                self.resetConnectionAndAttemptReconnect()
                 return
             }
         }
         reachability?.whenUnreachable = { [weak self] reachability in
-            guard let strongSelf = self else {
+            guard let self = self else {
                 print("Your Pusher instance has probably become deallocated. See https://github.com/pusher/pusher-websocket-swift/issues/109 for more information")
                 return
             }
 
-            strongSelf.delegate?.debugLog?(message: "[PUSHER DEBUG] Network unreachable")
-            strongSelf.resetConnectionAndAttemptReconnect()
+            self.delegate?.debugLog?(message: "[PUSHER DEBUG] Network unreachable")
+            self.resetConnectionAndAttemptReconnect()
         }
         return reachability
     }()

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -7,8 +7,8 @@ public typealias PusherEventJSON = [String: AnyObject]
 
 @objcMembers
 @objc open class PusherConnection: NSObject {
-    open let url: String
-    open let key: String
+    public let url: String
+    public let key: String
     open var options: PusherClientOptions
     open var globalChannel: GlobalChannel!
     open var socketId: String?

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -7,7 +7,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
 
 @objcMembers
 @objc open class Pusher: NSObject {
-    open let connection: PusherConnection
+    public let connection: PusherConnection
     open weak var delegate: PusherDelegate? = nil {
         willSet {
             self.connection.delegate = newValue

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -249,8 +249,8 @@ open class StubberForMocks {
 }
 
 open class FunctionCall {
-    open let name: String
-    open let args: [Any]?
+    public let name: String
+    public let args: [Any]?
 
     init(name: String, args: [Any]?) {
         self.name = name

--- a/Tests/PusherConnectionDelegateTests.swift
+++ b/Tests/PusherConnectionDelegateTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class PusherConnectionDelegateTests: XCTestCase {
     open class DummyDelegate: PusherDelegate {
-        open let stubber = StubberForMocks()
+        public let stubber = StubberForMocks()
         open var socket: MockWebSocket? = nil
         open var ex: XCTestExpectation? = nil
         var testingChannelName: String? = nil


### PR DESCRIPTION
### Description of the pull request
Upgrade the Swift version to 4.2. As part of the upgrade, this PR fixes compiler warnings that result in complier errors when using the library with Swift 5 and sets the Swift version in the Podspec so CocoaPods compiles it as Swift 4.2.
