### PR TITLE
Remove push notifications reference from comments

### DIFF
--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -20,8 +20,6 @@ let CLIENT_NAME = "pusher-websocket-swift"
 
         - parameter key:          The Pusher app key
         - parameter options:      An optional collection of options
-        - parameter nativePusher: A NativePusher instance for the app that the provided
-                                  key belongs to
 
         - returns: A new Pusher client instance
     */


### PR DESCRIPTION
### Description of the pull request
Removes a reference to "NativePusher" from push notifications that should have been removed.