### PR TITLE
WIP add user_id

### DIFF
--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		33BB997C1D21230100B25C2A /* PusherTopLevelAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BB99661D21226C00B25C2A /* PusherTopLevelAPITests.swift */; };
 		33C1FD6F1D81BFC300921AD7 /* ObjectiveC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */; };
 		33C40CB91C1DFC9C008A54E3 /* PusherSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 33831CD61A9CFFF200B124F1 /* PusherSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E24D0AA522D798C8009DE31B /* PusherEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24D0AA422D798C8009DE31B /* PusherEvent.swift */; };
+		E2CFE43122D79CA7004187C3 /* PusherParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CFE43022D79CA7004187C3 /* PusherParser.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +76,8 @@
 		33BB99661D21226C00B25C2A /* PusherTopLevelAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PusherTopLevelAPITests.swift; path = ../Tests/PusherTopLevelAPITests.swift; sourceTree = "<group>"; };
 		33BB99671D21226C00B25C2A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
 		33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveC.swift; sourceTree = "<group>"; };
+		E24D0AA422D798C8009DE31B /* PusherEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEvent.swift; sourceTree = "<group>"; };
+		E2CFE43022D79CA7004187C3 /* PusherParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherParser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,16 +124,18 @@
 				3389F5791CAEDEC800563F49 /* PusherClientOptions.swift */,
 				33BA541F1D9035BD00CD853B /* PusherDelegate.swift */,
 				3389F5651CAEDD5F00563F49 /* PusherConnection.swift */,
+				E2CFE43022D79CA7004187C3 /* PusherParser.swift */,
 				3389F5691CAEDD9100563F49 /* PusherWebsocketDelegate.swift */,
 				3384C1B81CAECD9C00F10796 /* PusherChannel.swift */,
 				3389F56D1CAEDDD800563F49 /* PusherPresenceChannel.swift */,
+				3390D1E71F054D1E00E1944D /* Authorizer.swift */,
 				3389F5751CAEDE2800563F49 /* PusherGlobalChannel.swift */,
 				3389F5711CAEDDF300563F49 /* PusherChannels.swift */,
 				3390D1E51F054D0400E1944D /* AuthRequestBuilderProtocol.swift */,
-				3390D1E71F054D1E00E1944D /* Authorizer.swift */,
 				33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */,
 				33831C8C1A9CF61600B124F1 /* Supporting Files */,
 				33831CD61A9CFFF200B124F1 /* PusherSwift.h */,
+				E24D0AA422D798C8009DE31B /* PusherEvent.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -253,6 +259,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 33831C491A9CEDF800B124F1;
@@ -310,10 +317,12 @@
 			files = (
 				3389F5661CAEDD5F00563F49 /* PusherConnection.swift in Sources */,
 				33BA54201D9035BD00CD853B /* PusherDelegate.swift in Sources */,
+				E24D0AA522D798C8009DE31B /* PusherEvent.swift in Sources */,
 				3389F56A1CAEDD9100563F49 /* PusherWebsocketDelegate.swift in Sources */,
 				330D7A6D1CAEDA750032FF2C /* PusherChannel.swift in Sources */,
 				3390D1E81F054D1E00E1944D /* Authorizer.swift in Sources */,
 				3389F5721CAEDDF300563F49 /* PusherChannels.swift in Sources */,
+				E2CFE43122D79CA7004187C3 /* PusherParser.swift in Sources */,
 				3389F5761CAEDE2800563F49 /* PusherGlobalChannel.swift in Sources */,
 				3389F57A1CAEDEC800563F49 /* PusherClientOptions.swift in Sources */,
 				3389F56E1CAEDDD800563F49 /* PusherPresenceChannel.swift in Sources */,

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -131,9 +131,9 @@ open class PusherChannel: NSObject {
         - parameter jsonObject:     The JSON payload received from the websocket
     */
     open func handleEvent(name: String, jsonObject: [String:Any]) {
-        // PusherEvent is a struct so will be passed by value to callbacks
-        let event = PusherEvent(eventName: name, payload: jsonObject, jsonize: self.shouldParseJSON)
         if let eventHandlerArray = self.eventHandlers[name] {
+            // PusherEvent is a struct so will be passed by value to callbacks
+            let event = PusherEvent(eventName: name, payload: jsonObject, jsonize: self.shouldParseJSON)
             for eventHandler in eventHandlerArray {
                 eventHandler.callback(event)
             }

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -61,9 +61,9 @@ open class PusherChannel: NSObject {
         Binds a callback to a given event name, scoped to the PusherChannel the function is
         called on
 
-        - parameter eventName:  The name of the event to bind to
-        - parameter callback:   The function to call when a message is received with the relevant
-                                    channel and event names
+        - parameter eventName: The name of the event to bind to
+        - parameter callback:  The function to call when a new event is received. The
+                               callback receives the event's data payload
 
         - returns: A unique callbackId that can be used to unbind the callback at a later time
     */
@@ -78,8 +78,9 @@ open class PusherChannel: NSObject {
      called on
 
      - parameter eventName:     The name of the event to bind to
-     - parameter eventCallback: The function to call when a message is received with the relevant
-                                channel and event names
+     - parameter eventCallback: The function to call when a new event is received. The callback
+                                receives a PusherEvent, containg the event's data payload and
+                                other properties.
 
      - returns: A unique callbackId that can be used to unbind the callback at a later time
      */
@@ -153,7 +154,6 @@ open class PusherChannel: NSObject {
             unsentEvents.insert(QueuedEvent(name: eventName, data: data), at: 0)
         }
     }
-
 }
 
 public struct EventHandler {

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -128,10 +128,9 @@ open class PusherChannel: NSObject {
         Calls the appropriate callbacks for the given eventName in the scope of the acted upon channel
 
         - parameter name:           The name of the received event
-        - parameter data:           The data associated with the received message
         - parameter jsonObject:     The JSON payload received from the websocket
     */
-    open func handleEvent(name: String, data: String, jsonObject: [String:Any]) {
+    open func handleEvent(name: String, jsonObject: [String:Any]) {
         if let eventHandlerArray = self.eventHandlers[name] {
             let event = PusherEvent(eventName: name, payload: jsonObject, jsonize: self.shouldParseJSON)
             for eventHandler in eventHandlerArray {

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -34,6 +34,12 @@ open class PusherChannel: NSObject {
     public let type: PusherChannelType
     public var auth: PusherAuth?
 
+    internal var shouldParseJSON: Bool {
+        get {
+            return connection?.options.attemptToReturnJSONObject ?? true
+        }
+    }
+
     /**
         Initializes a new PusherChannel with a given name and conenction
 
@@ -126,8 +132,7 @@ open class PusherChannel: NSObject {
     */
     open func handleEvent(name: String, data: String, jsonObject: [String:Any]) {
         if let eventHandlerArray = self.eventHandlers[name] {
-            let jsonize = connection?.options.attemptToReturnJSONObject ?? true
-            let event = PusherEvent(eventName: name, payload: jsonObject, jsonize: jsonize)
+            let event = PusherEvent(eventName: name, payload: jsonObject, jsonize: self.shouldParseJSON)
             for eventHandler in eventHandlerArray {
                 eventHandler.callback(event)
             }
@@ -148,6 +153,7 @@ open class PusherChannel: NSObject {
             unsentEvents.insert(QueuedEvent(name: eventName, data: data), at: 0)
         }
     }
+
 }
 
 public struct EventHandler {

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -79,7 +79,7 @@ open class PusherChannel: NSObject {
 
      - parameter eventName:     The name of the event to bind to
      - parameter eventCallback: The function to call when a new event is received. The callback
-                                receives a PusherEvent, containg the event's data payload and
+                                receives a PusherEvent, containing the event's data payload and
                                 other properties.
 
      - returns: A unique callbackId that can be used to unbind the callback at a later time
@@ -129,7 +129,7 @@ open class PusherChannel: NSObject {
 
         - parameter name:           The name of the received event
         - parameter data:           The data associated with the received message
-        - parameter jsonObject:    The JSON payload received from the websocket
+        - parameter jsonObject:     The JSON payload received from the websocket
     */
     open func handleEvent(name: String, data: String, jsonObject: [String:Any]) {
         if let eventHandlerArray = self.eventHandlers[name] {

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -55,8 +55,8 @@ open class PusherChannel: NSObject {
         Binds a callback to a given event name, scoped to the PusherChannel the function is
         called on
 
-        - parameter eventName:      The name of the event to bind to
-        - parameter eventCallback:  The function to call when a message is received with the relevant
+        - parameter eventName:  The name of the event to bind to
+        - parameter callback:   The function to call when a message is received with the relevant
                                     channel and event names
 
         - returns: A unique callbackId that can be used to unbind the callback at a later time
@@ -71,9 +71,9 @@ open class PusherChannel: NSObject {
      Binds a callback to a given event name, scoped to the PusherChannel the function is
      called on
 
-     - parameter eventName: The name of the event to bind to
-     - parameter callbackWithMetadata:  The function to call when a message is received with the relevant
-     channel and event names
+     - parameter eventName:     The name of the event to bind to
+     - parameter eventCallback: The function to call when a message is received with the relevant
+                                channel and event names
 
      - returns: A unique callbackId that can be used to unbind the callback at a later time
      */
@@ -120,13 +120,14 @@ open class PusherChannel: NSObject {
     /**
         Calls the appropriate callbacks for the given eventName in the scope of the acted upon channel
 
-        - parameter name: The name of the received event
-        - parameter data: The data associated with the received message
+        - parameter name:           The name of the received event
+        - parameter data:           The data associated with the received message
+        - parameter jsonObject:    The JSON payload received from the websocket
     */
-    open func handleEvent(name: String, data: String, jsonPayload: [String:Any]) {
+    open func handleEvent(name: String, data: String, jsonObject: [String:Any]) {
         if let eventHandlerArray = self.eventHandlers[name] {
             let jsonize = connection?.options.attemptToReturnJSONObject ?? true
-            let event = PusherEvent(payload: jsonPayload, eventName: name, jsonize: jsonize)
+            let event = PusherEvent(eventName: name, payload: jsonObject, jsonize: jsonize)
             for eventHandler in eventHandlerArray {
                 eventHandler.callback(event)
             }
@@ -154,7 +155,6 @@ public struct EventHandler {
     let callback: (PusherEvent) -> Void
 }
 
-// TODO: This is public. Is changing this a breaking change?
 public struct QueuedEvent {
     public let name: String
     public let data: Any

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -131,8 +131,9 @@ open class PusherChannel: NSObject {
         - parameter jsonObject:     The JSON payload received from the websocket
     */
     open func handleEvent(name: String, jsonObject: [String:Any]) {
+        // PusherEvent is a struct so will be passed by value to callbacks
+        let event = PusherEvent(eventName: name, payload: jsonObject, jsonize: self.shouldParseJSON)
         if let eventHandlerArray = self.eventHandlers[name] {
-            let event = PusherEvent(eventName: name, payload: jsonObject, jsonize: self.shouldParseJSON)
             for eventHandler in eventHandlerArray {
                 eventHandler.callback(event)
             }

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -481,7 +481,7 @@ public typealias PusherEventJSON = [String: AnyObject]
             }
 
             callGlobalCallbacks(forEvent: "pusher:subscription_succeeded", jsonObject: json)
-            chan.handleEvent(name: "pusher:subscription_succeeded", data: eventData, jsonObject: json)
+            chan.handleEvent(name: "pusher:subscription_succeeded", jsonObject: json)
 
             self.delegate?.subscribedToChannel?(name: channelName)
 
@@ -607,8 +607,8 @@ public typealias PusherEventJSON = [String: AnyObject]
         default:
             callGlobalCallbacks(forEvent: eventName, jsonObject: jsonObject)
             if let channelName = jsonObject["channel"] as? String, let internalChannel = self.channels.find(name: channelName) {
-                if let eName = jsonObject["event"] as? String, let eData = jsonObject["data"] as? String {
-                    internalChannel.handleEvent(name: eName, data: eData, jsonObject: jsonObject)
+                if let eName = jsonObject["event"] as? String {
+                    internalChannel.handleEvent(name: eName, jsonObject: jsonObject)
                 }
             }
         }

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -481,7 +481,7 @@ public typealias PusherEventJSON = [String: AnyObject]
             }
 
             callGlobalCallbacks(forEvent: "pusher:subscription_succeeded", jsonObject: json)
-            chan.handleEvent(name: "pusher:subscription_succeeded", data: eventData, jsonPayload: json)
+            chan.handleEvent(name: "pusher:subscription_succeeded", data: eventData, jsonObject: json)
 
             self.delegate?.subscribedToChannel?(name: channelName)
 
@@ -608,7 +608,7 @@ public typealias PusherEventJSON = [String: AnyObject]
             callGlobalCallbacks(forEvent: eventName, jsonObject: jsonObject)
             if let channelName = jsonObject["channel"] as? String, let internalChannel = self.channels.find(name: channelName) {
                 if let eName = jsonObject["event"] as? String, let eData = jsonObject["data"] as? String {
-                    internalChannel.handleEvent(name: eName, data: eData, jsonPayload: jsonObject)
+                    internalChannel.handleEvent(name: eName, data: eData, jsonObject: jsonObject)
                 }
             }
         }

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -12,7 +12,7 @@ public struct PusherEvent {
     /// The data payload of the event
     public let data: Any?
 
-    /// The Id of the user who triggered the event. Only present in client event on presence channels
+    /// The ID of the user who triggered the event. Only present in client event on presence channels
     public let userId: String?
 
     /**

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -32,8 +32,8 @@ public struct PusherEvent {
             self.data = payload["data"]
         }
 
-        self.channel = payload["channel"] as! String?
-        self.userId = payload["user_id"] as! String?
+        self.channel = payload["channel"] as? String
+        self.userId = payload["user_id"] as? String
         self.event = eventName
 
         // Replace the event name (so pusher_internal:subscription_succeeded can be mapped to pusher:subscription_succeeded)

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -1,47 +1,35 @@
-//
-//  PusherEvent.swift
-//  PusherSwift
-//
-//  Created by Tom Kemp on 11/07/2019.
-//
-
 import Foundation
 
-// TODO: Should we go with PusherChannelsEvent or PusherEvent
 public struct PusherEvent {
     internal let payload: [String:Any]
 
-    // According to channels protocol, there is always an event https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
-    //TODO: change to 'name'? 'eventName' might be better, or should it match the socket value
+    // According to Channels protocol, there is always an event https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
     public let event: String
     public let channel: String?
     public let data: Any?
+
     public let userId: String?
 
-    init(payload: [String:Any], eventName: String? = nil, jsonize: Bool){
-        var payloadCopy = payload
-
-        if let eventName = eventName {
-            self.event = eventName
-            payloadCopy["event"] = eventName
-        }else{
-            self.event = payloadCopy["event"] as! String
-        }
-        self.channel = payloadCopy["channel"] as! String?
-
-        if jsonize, let strongData = payloadCopy["data"] as? String {
+    init(eventName: String, payload: [String:Any], jsonize: Bool){
+        // Parse the data if necessary
+        if jsonize, let strongData = payload["data"] as? String {
             self.data = PusherParser.getEventDataJSON(from: strongData)
         }else{
-            self.data = payloadCopy["data"]
+            self.data = payload["data"]
         }
 
-        self.userId = payloadCopy["user_id"] as! String?
+        self.event = eventName
+        self.channel = payload["channel"] as! String?
+        self.userId = payload["user_id"] as! String?
+
+        // Replace the event name (so pusher_internal:subscription_succeeded can be mapped to pusher:subscription_succeeded)
+        var payloadCopy = payload
+        payloadCopy["event"] = eventName
+
         self.payload = payloadCopy
     }
 
-    // Is "data" metadata? getRaw maybe. The JSON won't be parsed as it stands
-    // the word key is there twice?
-    public func getKey(key: String) -> Any?{
-        return payload[key]
+    public func getProperty(name: String) -> Any?{
+        return payload[name]
     }
 }

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -6,9 +6,9 @@ public struct PusherEvent {
 
     // According to Channels protocol, there is always an event https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
     /// The name of the event
-    public let name: String
+    public let eventName: String
     /// The name of the channel that the event is associated with, e.g. "my-channel". Not present in events without an associated channel, e.g. "pusher:error" events relating to the connection
-    public let channel: String?
+    public let channelName: String?
     /// The data payload of the event
     public let data: Any?
 
@@ -32,9 +32,9 @@ public struct PusherEvent {
             self.data = payload["data"]
         }
 
-        self.channel = payload["channel"] as? String
+        self.channelName = payload["channel"] as? String
         self.userId = payload["user_id"] as? String
-        self.name = eventName
+        self.eventName = eventName
 
         // Replace the event name (so pusher_internal:subscription_succeeded can be mapped to pusher:subscription_succeeded)
         var payloadCopy = payload

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -6,13 +6,13 @@ public struct PusherEvent {
 
     // According to Channels protocol, there is always an event https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
     /// The name of the event
-    public let event: String
-    /// The name of the channel that the event was received on. Not present in `pusher:error` events
+    public let name: String
+    /// The name of the channel that the event is associated with, e.g. "my-channel". Not present in events without an associated channel, e.g. "pusher:error" events relating to the connection
     public let channel: String?
     /// The data payload of the event
     public let data: Any?
 
-    /// The Id of the user who triggered the event. Only present in client events.
+    /// The Id of the user who triggered the event. Only present in client event on presence channels
     public let userId: String?
 
     /**
@@ -20,7 +20,7 @@ public struct PusherEvent {
 
      - parameter eventName: The name of the event. This will override the event name in the payload
      - parameter payload:   The JSON payload received from the websocket
-     - parameter jsonize:   Determines whether an attempt will be made to parse the data parameter to JSON
+     - parameter jsonize:   Determines whether an attempt will be made to parse the data property to JSON
 
      - returns: A new Pusher event
      */
@@ -34,7 +34,7 @@ public struct PusherEvent {
 
         self.channel = payload["channel"] as? String
         self.userId = payload["user_id"] as? String
-        self.event = eventName
+        self.name = eventName
 
         // Replace the event name (so pusher_internal:subscription_succeeded can be mapped to pusher:subscription_succeeded)
         var payloadCopy = payload

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -1,16 +1,30 @@
 import Foundation
 
 public struct PusherEvent {
+    /// The JSON payload received from the websocket
     internal let payload: [String:Any]
 
     // According to Channels protocol, there is always an event https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
+    /// The name of the event
     public let event: String
+    /// The name of the channel that the event was received on. Not present in `pusher:error` events
     public let channel: String?
+    /// The data payload of the event
     public let data: Any?
 
+    /// The Id of the user who triggered the event. Only present in client events.
     public let userId: String?
 
-    init(eventName: String, payload: [String:Any], jsonize: Bool){
+    /**
+     Initializes a Pusher event
+
+     - parameter eventName: The name of the event. This will override the event name in the payload
+     - parameter payload:   The JSON payload received from the websocket
+     - parameter jsonize:   Determines whether an attempt will be made to parse the data parameter to JSON
+
+     - returns: A new Pusher event
+     */
+    internal init(eventName: String, payload: [String:Any], jsonize: Bool){
         // Parse the data if necessary
         if jsonize, let strongData = payload["data"] as? String {
             self.data = PusherParser.getEventDataJSON(from: strongData)
@@ -18,9 +32,9 @@ public struct PusherEvent {
             self.data = payload["data"]
         }
 
-        self.event = eventName
         self.channel = payload["channel"] as! String?
         self.userId = payload["user_id"] as! String?
+        self.event = eventName
 
         // Replace the event name (so pusher_internal:subscription_succeeded can be mapped to pusher:subscription_succeeded)
         var payloadCopy = payload
@@ -29,6 +43,13 @@ public struct PusherEvent {
         self.payload = payloadCopy
     }
 
+    /**
+     Returns unparsed properties from the event JSON payload
+
+     - parameter name: The name of the property to be returned
+
+     - returns: The named property, if present
+     */
     public func getProperty(name: String) -> Any?{
         return payload[name]
     }

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -1,0 +1,47 @@
+//
+//  PusherEvent.swift
+//  PusherSwift
+//
+//  Created by Tom Kemp on 11/07/2019.
+//
+
+import Foundation
+
+// TODO: Should we go with PusherChannelsEvent or PusherEvent
+public struct PusherEvent {
+    internal let payload: [String:Any]
+
+    // According to channels protocol, there is always an event https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
+    //TODO: change to 'name'? 'eventName' might be better, or should it match the socket value
+    public let event: String
+    public let channel: String?
+    public let data: Any?
+    public let userId: String?
+
+    init(payload: [String:Any], eventName: String? = nil, jsonize: Bool){
+        var payloadCopy = payload
+
+        if let eventName = eventName {
+            self.event = eventName
+            payloadCopy["event"] = eventName
+        }else{
+            self.event = payloadCopy["event"] as! String
+        }
+        self.channel = payloadCopy["channel"] as! String?
+
+        if jsonize, let strongData = payloadCopy["data"] as? String {
+            self.data = PusherParser.getEventDataJSON(from: strongData)
+        }else{
+            self.data = payloadCopy["data"]
+        }
+
+        self.userId = payloadCopy["user_id"] as! String?
+        self.payload = payloadCopy
+    }
+
+    // Is "data" metadata? getRaw maybe. The JSON won't be parsed as it stands
+    // the word key is there twice?
+    public func getKey(key: String) -> Any?{
+        return payload[key]
+    }
+}

--- a/Sources/PusherGlobalChannel.swift
+++ b/Sources/PusherGlobalChannel.swift
@@ -24,12 +24,12 @@ import Foundation
                                  to, if relevant
     */
     internal func handleEvent(name: String, data: String, channelName: String?) {
+        var payload: [String: Any] = ["event": name, "data": data]
+        if let channelName = channelName {
+            payload["channel"] = channelName
+        }
+        let event = PusherEvent(eventName: name, payload: payload, jsonize: self.shouldParseJSON)
         for (_, callback) in self.globalCallbacks {
-            var payload: [String: Any] = ["event": name, "data": data]
-            if let channelName = channelName {
-                payload["channel"] = channelName
-            }
-            let event = PusherEvent(eventName: name, payload: payload, jsonize: self.shouldParseJSON)
             callback(event)
         }
     }
@@ -41,9 +41,9 @@ import Foundation
         - parameter data: The data associated with the received message
     */
     internal func handleErrorEvent(name: String, data: [String: AnyObject]) {
+        let payload = ["event": name, "data": data] as [String: Any]
+        let event = PusherEvent(eventName: name, payload: payload, jsonize: false)
         for (_, callback) in self.globalCallbacks {
-            let payload = ["event": name, "data": data] as [String: Any]
-            let event = PusherEvent(eventName: name, payload: payload, jsonize: false)
             callback(event)
         }
     }

--- a/Sources/PusherGlobalChannel.swift
+++ b/Sources/PusherGlobalChannel.swift
@@ -27,15 +27,12 @@ import Foundation
         //TODO: this is duplicated from Pusher channel
         let jsonize = connection?.options.attemptToReturnJSONObject ?? true
         for (_, callback) in self.globalCallbacks {
+            var payload = ["event": name, "data": data] as [String: Any]
             if let channelName = channelName {
-                let payload = ["channel": channelName, "event": name, "data": data] as [String: Any]
-                let event = PusherEvent(payload: payload, eventName: name, jsonize: jsonize)
-                callback(event)
-            } else {
-                let payload = ["event": name, "data": data] as [String: Any]
-                let event = PusherEvent(payload: payload, eventName: name, jsonize: jsonize)
-                callback(event)
+                payload["channel"] = channelName
             }
+            let event = PusherEvent(payload: payload, eventName: name, jsonize: jsonize)
+            callback(event)
         }
     }
 

--- a/Sources/PusherGlobalChannel.swift
+++ b/Sources/PusherGlobalChannel.swift
@@ -24,7 +24,7 @@ import Foundation
                                  to, if relevant
     */
     internal func handleEvent(name: String, data: String, channelName: String?) {
-        var payload: [String: Any] = ["event": name, "data": data]
+        var payload = ["event": name, "data": data] as [String: Any]
         if let channelName = channelName {
             payload["channel"] = channelName
         }

--- a/Sources/PusherGlobalChannel.swift
+++ b/Sources/PusherGlobalChannel.swift
@@ -24,14 +24,12 @@ import Foundation
                                  to, if relevant
     */
     internal func handleEvent(name: String, data: String, channelName: String?) {
-        //TODO: this is duplicated from Pusher channel
-        let jsonize = connection?.options.attemptToReturnJSONObject ?? true
         for (_, callback) in self.globalCallbacks {
             var payload: [String: Any] = ["event": name, "data": data]
             if let channelName = channelName {
                 payload["channel"] = channelName
             }
-            let event = PusherEvent(eventName: name, payload: payload, jsonize: jsonize)
+            let event = PusherEvent(eventName: name, payload: payload, jsonize: self.shouldParseJSON)
             callback(event)
         }
     }

--- a/Sources/PusherGlobalChannel.swift
+++ b/Sources/PusherGlobalChannel.swift
@@ -27,11 +27,11 @@ import Foundation
         //TODO: this is duplicated from Pusher channel
         let jsonize = connection?.options.attemptToReturnJSONObject ?? true
         for (_, callback) in self.globalCallbacks {
-            var payload = ["event": name, "data": data] as [String: Any]
+            var payload: [String: Any] = ["event": name, "data": data]
             if let channelName = channelName {
                 payload["channel"] = channelName
             }
-            let event = PusherEvent(payload: payload, eventName: name, jsonize: jsonize)
+            let event = PusherEvent(eventName: name, payload: payload, jsonize: jsonize)
             callback(event)
         }
     }
@@ -45,7 +45,7 @@ import Foundation
     internal func handleErrorEvent(name: String, data: [String: AnyObject]) {
         for (_, callback) in self.globalCallbacks {
             let payload = ["event": name, "data": data] as [String: Any]
-            let event = PusherEvent(payload: payload, eventName: name, jsonize: false)
+            let event = PusherEvent(eventName: name, payload: payload, jsonize: false)
             callback(event)
         }
     }

--- a/Sources/PusherParser.swift
+++ b/Sources/PusherParser.swift
@@ -1,10 +1,3 @@
-//
-//  PusherParser.swift
-//  PusherSwift
-//
-//  Created by Tom Kemp on 11/07/2019.
-//
-
 import Foundation
 
 internal class PusherParser: NSObject {

--- a/Sources/PusherParser.swift
+++ b/Sources/PusherParser.swift
@@ -1,0 +1,55 @@
+//
+//  PusherParser.swift
+//  PusherSwift
+//
+//  Created by Tom Kemp on 11/07/2019.
+//
+
+import Foundation
+
+internal class PusherParser: NSObject {
+
+    /**
+     Parse a string to extract Pusher event information from it
+
+     - parameter string: The string received over the websocket connection containing
+     Pusher event information
+
+     - returns: A dictionary of Pusher-relevant event data
+     */
+
+    class func getPusherEventJSON(from string: String) -> [String : AnyObject]? {
+        let data = (string as NSString).data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false)
+
+        do {
+            if let jsonData = data, let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String : AnyObject] {
+                return jsonObject
+            } else {
+                print("Unable to parse string from WebSocket: \(string)")
+            }
+        } catch let error as NSError {
+            print("Error: \(error.localizedDescription)")
+        }
+        return nil
+    }
+
+    /**
+     Parse a string to extract Pusher event data from it
+
+     - parameter string: The data string received as part of a Pusher message
+
+     - returns: The object sent as the payload part of the Pusher message
+     */
+    class func getEventDataJSON(from string: String) -> Any {
+        let data = (string as NSString).data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false)
+
+        do {
+            if let jsonData = data, let jsonObject = try? JSONSerialization.jsonObject(with: jsonData, options: []) {
+                return jsonObject
+            } else {
+                print("Returning data string instead because unable to parse string as JSON - check that your JSON is valid.")
+            }
+        }
+        return string
+    }
+}

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -119,7 +119,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
     /**
      Binds the client's global channel to all events
 
-     - parameter callback: The function to call when a new event is received
+     - parameter eventCallback: The function to call when a new event is received
 
      - returns: A unique string that can be used to unbind the callback from the client
      */

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -106,7 +106,8 @@ let CLIENT_NAME = "pusher-websocket-swift"
     /**
         Binds the client's global channel to all events
 
-        - parameter callback: The function to call when a new event is received. Callback receives the event data
+        - parameter callback: The function to call when a new event is received. The callback
+                              receives the event's data payload
 
         - returns: A unique string that can be used to unbind the callback from the client
     */
@@ -119,7 +120,9 @@ let CLIENT_NAME = "pusher-websocket-swift"
     /**
      Binds the client's global channel to all events
 
-     - parameter eventCallback: The function to call when a new event is received. Callback receives a PusherEvent
+     - parameter eventCallback: The function to call when a new event is received. The callback
+                                receives a PusherEvent, containg the event's data payload and
+                                other properties.
 
      - returns: A unique string that can be used to unbind the callback from the client
      */
@@ -130,7 +133,8 @@ let CLIENT_NAME = "pusher-websocket-swift"
     /**
         Unbinds the client from its global channel
 
-        - parameter callbackId: The unique callbackId string used to identify which callback to unbind
+        - parameter callbackId: The unique callbackId string used to identify which callback
+                                to unbind
     */
     open func unbind(callbackId: String) {
         self.connection.removeCallbackFromGlobalChannel(callbackId: callbackId)

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -121,7 +121,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
      Binds the client's global channel to all events
 
      - parameter eventCallback: The function to call when a new event is received. The callback
-                                receives a PusherEvent, containg the event's data payload and
+                                receives a PusherEvent, containing the event's data payload and
                                 other properties.
 
      - returns: A unique string that can be used to unbind the callback from the client

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -111,7 +111,20 @@ let CLIENT_NAME = "pusher-websocket-swift"
         - returns: A unique string that can be used to unbind the callback from the client
     */
     @discardableResult open func bind(_ callback: @escaping (Any?) -> Void) -> String {
-        return self.connection.addCallbackToGlobalChannel(callback)
+        return bind(eventCallback: { (event: PusherEvent) -> Void in
+            callback(event.payload)
+        })
+    }
+
+    /**
+     Binds the client's global channel to all events
+
+     - parameter callback: The function to call when a new event is received
+
+     - returns: A unique string that can be used to unbind the callback from the client
+     */
+    @discardableResult open func bind(eventCallback: @escaping (PusherEvent) -> Void) -> String {
+        return self.connection.addCallbackToGlobalChannel(eventCallback)
     }
 
     /**

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -106,7 +106,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
     /**
         Binds the client's global channel to all events
 
-        - parameter callback: The function to call when a new event is received
+        - parameter callback: The function to call when a new event is received. Callback receives the event data
 
         - returns: A unique string that can be used to unbind the callback from the client
     */
@@ -119,7 +119,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
     /**
      Binds the client's global channel to all events
 
-     - parameter eventCallback: The function to call when a new event is received
+     - parameter eventCallback: The function to call when a new event is received. Callback receives a PusherEvent
 
      - returns: A unique string that can be used to unbind the callback from the client
      */

--- a/Sources/PusherWebsocketDelegate.swift
+++ b/Sources/PusherWebsocketDelegate.swift
@@ -11,7 +11,7 @@ extension PusherConnection: WebSocketDelegate {
     */
     public func websocketDidReceiveMessage(socket ws: WebSocketClient, text: String) {
         self.delegate?.debugLog?(message: "[PUSHER DEBUG] websocketDidReceiveMessage \(text)")
-        if let pusherPayloadObject = getPusherEventJSON(from: text), let eventName = pusherPayloadObject["event"] as? String {
+        if let pusherPayloadObject = PusherParser.getPusherEventJSON(from: text), let eventName = pusherPayloadObject["event"] as? String {
             self.handleEvent(eventName: eventName, jsonObject: pusherPayloadObject)
         } else {
             self.delegate?.debugLog?(message: "[PUSHER DEBUG] Unable to handle incoming Websocket message \(text)")

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -5,6 +5,7 @@ open class MockWebSocket: WebSocket {
     let stubber = StubberForMocks()
     var callbackCheckString: String = ""
     var objectGivenToCallback: Any? = nil
+    var eventGivenToCallback: PusherEvent? = nil
 
     init() {
         var request = URLRequest(url: URL(string: "test")!)
@@ -18,6 +19,10 @@ open class MockWebSocket: WebSocket {
 
     open func storeDataObjectGivenToCallback(_ data: Any) {
         self.objectGivenToCallback = data
+    }
+
+    open func storeEventGivenToCallback(_ event: PusherEvent) {
+        self.eventGivenToCallback = event
     }
 
     open override func connect() {

--- a/Tests/PusherChannelTests.swift
+++ b/Tests/PusherChannelTests.swift
@@ -23,10 +23,20 @@ class PusherChannelTests: XCTestCase {
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 1, "the channel should have one callback")
     }
 
-    func testUnbindingACallbackForAGivenEventNameAndCallbackId() {
+    func testUnbindingADataCallbackForAGivenEventNameAndCallbackId() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
         let idOne = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
+        let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
+        XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
+        chan.unbind(eventName: "test-event", callbackId: idOne)
+        XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 1, "the channel should have one callback for event \"test-event\"")
+    }
+
+    func testUnbindingAnEventCallbackForAGivenEventNameAndCallbackId() {
+        let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
+        XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
+        let idOne = chan.bind(eventName: "test-event", eventCallback: { (event: PusherEvent) -> Void in })
         let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
         chan.unbind(eventName: "test-event", callbackId: idOne)
@@ -37,7 +47,7 @@ class PusherChannelTests: XCTestCase {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
         let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
-        let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
+        let _ = chan.bind(eventName: "test-event", eventCallback: { (event: PusherEvent) -> Void in })
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
         chan.unbindAll(forEventName: "test-event")
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 0, "the channel should have no callbacks for event \"test-event\"")
@@ -47,7 +57,7 @@ class PusherChannelTests: XCTestCase {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertEqual(chan.eventHandlers.count, 0, "the channel should have no callbacks")
         let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
-        let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
+        let _ = chan.bind(eventName: "test-event", eventCallback: { (event: PusherEvent) -> Void in })
         let _ = chan.bind(eventName: "test-event-3", callback: { (data: Any?) -> Void in })
         XCTAssertEqual(chan.eventHandlers.count, 2, "the channel should have two event names with callbacks")
         chan.unbindAll()

--- a/Tests/PusherIncomingEventHandlingTests.swift
+++ b/Tests/PusherIncomingEventHandlingTests.swift
@@ -173,11 +173,11 @@ class HandlingIncomingEventsTests: XCTestCase {
 
         XCTAssertNil(event.userId)
 
-        XCTAssertEqual(event.getKey(key: "event") as! String, "test-event")
-        XCTAssertEqual(event.getKey(key: "channel") as! String, "my-channel")
-        XCTAssertEqual(event.getKey(key: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
+        XCTAssertEqual(event.getProperty(name: "event") as! String, "test-event")
+        XCTAssertEqual(event.getProperty(name: "channel") as! String, "my-channel")
+        XCTAssertEqual(event.getProperty(name: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
 
-        XCTAssertNil(event.getKey(key: "random-key"))
+        XCTAssertNil(event.getProperty(name: "random-key"))
     }
 
 
@@ -199,11 +199,11 @@ class HandlingIncomingEventsTests: XCTestCase {
 
         XCTAssertNil(event.userId)
 
-        XCTAssertEqual(event.getKey(key: "event") as! String, "test-event")
-        XCTAssertEqual(event.getKey(key: "channel") as! String, "my-channel")
-        XCTAssertEqual(event.getKey(key: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
+        XCTAssertEqual(event.getProperty(name: "event") as! String, "test-event")
+        XCTAssertEqual(event.getProperty(name: "channel") as! String, "my-channel")
+        XCTAssertEqual(event.getProperty(name: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
 
-        XCTAssertNil(event.getKey(key: "random-key"))
+        XCTAssertNil(event.getProperty(name: "random-key"))
     }
 
     func testReturningJSONStringInEventCallbacksIfTheStringCannotBeParsed() {
@@ -219,7 +219,7 @@ class HandlingIncomingEventsTests: XCTestCase {
         }
 
         XCTAssertEqual(event.data as! String, "test")
-        XCTAssertEqual(event.getKey(key: "data") as! String, "test")
+        XCTAssertEqual(event.getProperty(name: "data") as! String, "test")
     }
 
     func testReturningJSONStringInEventCallbacksIfTheStringCanBeParsedButAttemptToReturnJSONObjectIsFalse() {
@@ -239,7 +239,7 @@ class HandlingIncomingEventsTests: XCTestCase {
         }
 
         XCTAssertEqual(event.data as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
-        XCTAssertEqual(event.getKey(key: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
+        XCTAssertEqual(event.getProperty(name: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
     }
 
     func testAccessingANewKeyInTheEventObject(){
@@ -254,7 +254,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             return XCTFail("Event not received.")
         }
 
-        XCTAssertEqual(event.getKey(key: "new-feature") as! String, "This is the value")
+        XCTAssertEqual(event.getProperty(name: "new-feature") as! String, "This is the value")
     }
 
     func testEventObjectContainsUserId(){
@@ -280,6 +280,6 @@ class HandlingIncomingEventsTests: XCTestCase {
         }
 
         XCTAssertEqual(event.userId, "user12345")
-        XCTAssertEqual(event.getKey(key: "user_id") as! String, "user12345")
+        XCTAssertEqual(event.getProperty(name: "user_id") as! String, "user12345")
     }
 }

--- a/Tests/PusherIncomingEventHandlingTests.swift
+++ b/Tests/PusherIncomingEventHandlingTests.swift
@@ -145,7 +145,7 @@ class HandlingIncomingEventsTests: XCTestCase {
 
     func testReceivingAnErrorWhereTheDataPartOfTheMessageIsNotDoubleEncodedViaEventCallback() {
         let _ = pusher.bind(eventCallback:{ (event: PusherEvent) in
-            if event.name == "pusher:error" {
+            if event.eventName == "pusher:error" {
                 if let data = event.data as? [String: AnyObject], let errorMessage = data["message"] as? String {
                     self.socket.appendToCallbackCheckString(errorMessage)
                 }
@@ -167,8 +167,8 @@ class HandlingIncomingEventsTests: XCTestCase {
             return XCTFail("Event not received.")
         }
 
-        XCTAssertEqual(event.name, "test-event")
-        XCTAssertEqual(event.channel!, "my-channel")
+        XCTAssertEqual(event.eventName, "test-event")
+        XCTAssertEqual(event.channelName!, "my-channel")
         XCTAssertEqual(event.data as! [String: String], ["test": "test string", "and": "another"])
 
         XCTAssertNil(event.userId)
@@ -193,8 +193,8 @@ class HandlingIncomingEventsTests: XCTestCase {
             return XCTFail("Event not received.")
         }
 
-        XCTAssertEqual(event.name, "test-event")
-        XCTAssertEqual(event.channel!, "my-channel")
+        XCTAssertEqual(event.eventName, "test-event")
+        XCTAssertEqual(event.channelName!, "my-channel")
         XCTAssertEqual(event.data as! [String: String], ["test": "test string", "and": "another"])
 
         XCTAssertNil(event.userId)

--- a/Tests/PusherIncomingEventHandlingTests.swift
+++ b/Tests/PusherIncomingEventHandlingTests.swift
@@ -81,7 +81,7 @@ class HandlingIncomingEventsTests: XCTestCase {
         XCTAssertEqual(socket.objectGivenToCallback as? String, "{\"test\":\"test string\",\"and\":\"another\"}")
     }
 
-    func testReceivingAnErrorWhereTheDataPartOfTheMessageIsNotDoubleEncoded() {
+    func testReceivingAnErrorWhereTheDataPartOfTheMessageIsNotDoubleEncodedViaDataCallback() {
         let _ = pusher.bind({ (message: Any?) in
             if let message = message as? [String: AnyObject], let eventName = message["event"] as? String, eventName == "pusher:error" {
                 if let data = message["data"] as? [String: AnyObject], let errorMessage = data["message"] as? String {
@@ -94,8 +94,147 @@ class HandlingIncomingEventsTests: XCTestCase {
         // back from Pusher
         pusher.connection.handleEvent(eventName: "pusher:error", jsonObject: ["event": "pusher:error" as AnyObject, "data": ["code": "<null>", "message": "Existing subscription to channel my-channel"] as AnyObject])
 
+        XCTAssertEqual(socket.callbackCheckString, "Existing subscription to channel my-channel")
+    }
+
+    func testReceivingAnErrorWhereTheDataPartOfTheMessageIsNotDoubleEncodedViaEventCallback() {
+        let _ = pusher.bind(eventCallback:{ (event: PusherEvent) in
+            if event.event == "pusher:error" {
+                if let data = event.data as? [String: AnyObject], let errorMessage = data["message"] as? String {
+                    self.socket.appendToCallbackCheckString(errorMessage)
+                }
+            }
+        })
+
+        pusher.connection.handleEvent(eventName: "pusher:error", jsonObject: ["event": "pusher:error" as AnyObject, "data": ["code": "<null>", "message": "Existing subscription to channel my-channel"] as AnyObject])
+
+        XCTAssertEqual(socket.callbackCheckString, "Existing subscription to channel my-channel")
+    }
+
+    func testEventObjectReturnedToChannelCallback() {
+        let callback = { (event: PusherEvent) -> Void in self.socket.storeEventGivenToCallback(event) }
+        let chan = pusher.subscribe("my-channel")
+        let _ = chan.bind(eventName: "test-event", eventCallback: callback)
+
+        XCTAssertNil(socket.eventGivenToCallback)
+        pusher.connection.handleEvent(eventName: "test-event", jsonObject: ["event": "test-event" as AnyObject, "channel": "my-channel" as AnyObject, "data": "{\"test\":\"test string\",\"and\":\"another\"}" as AnyObject])
+
+        guard let event = socket.eventGivenToCallback else {
+            return XCTFail("Event not received.")
+        }
+
+        XCTAssertEqual(event.event, "test-event")
+        XCTAssertEqual(event.channel!, "my-channel")
+        XCTAssertEqual(event.data as! [String: String], ["test": "test string", "and": "another"])
+
+        XCTAssertNil(event.userId)
+
+        XCTAssertEqual(event.getKey(key: "event") as! String, "test-event")
+        XCTAssertEqual(event.getKey(key: "channel") as! String, "my-channel")
+        XCTAssertEqual(event.getKey(key: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
+
+        XCTAssertNil(event.getKey(key: "random-key"))
+    }
+
+    func testEventObjectReturnedToGlobalCallback() {
+        let callback = { (event: PusherEvent) -> Void in self.socket.storeEventGivenToCallback(event) }
+        let _ = pusher.subscribe("my-channel")
+        let _ = pusher.bind(eventCallback: callback)
+
+        XCTAssertNil(socket.eventGivenToCallback)
+        pusher.connection.handleEvent(eventName: "test-event", jsonObject: ["event": "test-event" as AnyObject, "channel": "my-channel" as AnyObject, "data": "{\"test\":\"test string\",\"and\":\"another\"}" as AnyObject])
+
+        guard let event = socket.eventGivenToCallback else {
+            return XCTFail("Event not received.")
+        }
+
+        XCTAssertEqual(event.event, "test-event")
+        XCTAssertEqual(event.channel!, "my-channel")
+        XCTAssertEqual(event.data as! [String: String], ["test": "test string", "and": "another"])
+
+        XCTAssertNil(event.userId)
+
+        XCTAssertEqual(event.getKey(key: "event") as! String, "test-event")
+        XCTAssertEqual(event.getKey(key: "channel") as! String, "my-channel")
+        XCTAssertEqual(event.getKey(key: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
+
+        XCTAssertNil(event.getKey(key: "random-key"))
+    }
+
+    func testReturningJSONStringInEventCallbacksIfTheStringCannotBeParsed() {
+        let callback = { (event: PusherEvent) -> Void in self.socket.storeEventGivenToCallback(event) }
+        let chan = pusher.subscribe("my-channel")
+        let _ = chan.bind(eventName: "test-event", eventCallback: callback)
+
         XCTAssertNil(socket.objectGivenToCallback)
         pusher.connection.handleEvent(eventName: "test-event", jsonObject: ["event": "test-event" as AnyObject, "channel": "my-channel" as AnyObject, "data": "test" as AnyObject])
-        XCTAssertEqual(socket.callbackCheckString, "Existing subscription to channel my-channel")
+
+        guard let event = socket.eventGivenToCallback else {
+            return XCTFail("Event not received.")
+        }
+
+        XCTAssertEqual(event.data as! String, "test")
+        XCTAssertEqual(event.getKey(key: "data") as! String, "test")
+    }
+
+    func testReturningJSONStringInEventCallbacksIfTheStringCanBeParsedButAttemptToReturnJSONObjectIsFalse() {
+        let options = PusherClientOptions(attemptToReturnJSONObject: false)
+        pusher = Pusher(key: key, options: options)
+        socket.delegate = pusher.connection
+        pusher.connection.socket = socket
+        let callback = { (event: PusherEvent) -> Void in self.socket.storeEventGivenToCallback(event) }
+        let chan = pusher.subscribe("my-channel")
+        let _ = chan.bind(eventName: "test-event", eventCallback: callback)
+
+        XCTAssertNil(socket.objectGivenToCallback)
+        pusher.connection.handleEvent(eventName: "test-event", jsonObject: ["event": "test-event" as AnyObject, "channel": "my-channel" as AnyObject, "data": "{\"test\":\"test string\",\"and\":\"another\"}" as AnyObject])
+
+        guard let event = socket.eventGivenToCallback else {
+            return XCTFail("Event not received.")
+        }
+
+        XCTAssertEqual(event.data as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
+        XCTAssertEqual(event.getKey(key: "data") as! String, "{\"test\":\"test string\",\"and\":\"another\"}")
+    }
+
+    func testAccessingANewKeyInTheEventObject(){
+        let callback = { (event: PusherEvent) -> Void in self.socket.storeEventGivenToCallback(event) }
+        let chan = pusher.subscribe("my-channel")
+        let _ = chan.bind(eventName: "test-event", eventCallback: callback)
+
+        XCTAssertNil(socket.eventGivenToCallback)
+        pusher.connection.handleEvent(eventName: "test-event", jsonObject: ["new-feature": "This is the value" as AnyObject, "event": "test-event" as AnyObject, "channel": "my-channel" as AnyObject, "data": "{\"test\":\"test string\",\"and\":\"another\"}" as AnyObject])
+
+        guard let event = socket.eventGivenToCallback else {
+            return XCTFail("Event not received.")
+        }
+
+        XCTAssertEqual(event.getKey(key: "new-feature") as! String, "This is the value")
+    }
+
+    func testEventObjectContainsUserId(){
+        let options = PusherClientOptions(
+            authMethod: .inline(secret: "secret"),
+            autoReconnect: false
+        )
+        pusher = Pusher(key: "key", options: options)
+        socket.delegate = pusher.connection
+        pusher.connection.socket = socket
+
+        let pusher = Pusher(withAppKey: key, options: options)
+
+        let callback = { (event: PusherEvent) -> Void in self.socket.storeEventGivenToCallback(event) }
+        let chan = pusher.subscribe("private-test-channel")
+        let _ = chan.bind(eventName: "client-test-event", eventCallback: callback)
+
+        XCTAssertNil(socket.eventGivenToCallback)
+        pusher.connection.handleEvent(eventName: "client-test-event", jsonObject: ["user_id": "user12345" as AnyObject, "event": "client-test-event" as AnyObject, "channel": "private-test-channel" as AnyObject, "data": "{}" as AnyObject])
+
+        guard let event = socket.eventGivenToCallback else {
+            return XCTFail("Event not received.")
+        }
+
+        XCTAssertEqual(event.userId, "user12345")
+        XCTAssertEqual(event.getKey(key: "user_id") as! String, "user12345")
     }
 }

--- a/Tests/PusherIncomingEventHandlingTests.swift
+++ b/Tests/PusherIncomingEventHandlingTests.swift
@@ -145,7 +145,7 @@ class HandlingIncomingEventsTests: XCTestCase {
 
     func testReceivingAnErrorWhereTheDataPartOfTheMessageIsNotDoubleEncodedViaEventCallback() {
         let _ = pusher.bind(eventCallback:{ (event: PusherEvent) in
-            if event.event == "pusher:error" {
+            if event.name == "pusher:error" {
                 if let data = event.data as? [String: AnyObject], let errorMessage = data["message"] as? String {
                     self.socket.appendToCallbackCheckString(errorMessage)
                 }
@@ -167,7 +167,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             return XCTFail("Event not received.")
         }
 
-        XCTAssertEqual(event.event, "test-event")
+        XCTAssertEqual(event.name, "test-event")
         XCTAssertEqual(event.channel!, "my-channel")
         XCTAssertEqual(event.data as! [String: String], ["test": "test string", "and": "another"])
 
@@ -193,7 +193,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             return XCTFail("Event not received.")
         }
 
-        XCTAssertEqual(event.event, "test-event")
+        XCTAssertEqual(event.name, "test-event")
         XCTAssertEqual(event.channel!, "my-channel")
         XCTAssertEqual(event.data as! [String: String], ["test": "test string", "and": "another"])
 

--- a/Tests/PusherTopLevelAPITests.swift
+++ b/Tests/PusherTopLevelAPITests.swift
@@ -302,10 +302,20 @@ class PusherTopLevelApiTests: XCTestCase {
         XCTAssertEqual(pusher.connection.globalChannel?.globalCallbacks.count, 1, "the global channel should have 1 bound callback")
     }
 
-    func testUnbindingAGlobalCallbackRemovesItFromTheGlobalChannelsCallbackList() {
+    func testUnbindingAGlobalDataCallbackRemovesItFromTheGlobalChannelsCallbackList() {
         pusher.connect()
         let callback = { (data: Any?) in }
         let callBackId = pusher.bind(callback)
+
+        XCTAssertEqual(pusher.connection.globalChannel?.globalCallbacks.count, 1, "the global channel should have 1 bound callback")
+        pusher.unbind(callbackId: callBackId)
+        XCTAssertEqual(pusher.connection.globalChannel?.globalCallbacks.count, 0, "the global channel should not have any bound callbacks")
+    }
+
+    func testUnbindingAGlobalEventCallbackRemovesItFromTheGlobalChannelsCallbackList() {
+        pusher.connect()
+        let callback = { (event: PusherEvent) in }
+        let callBackId = pusher.bind(eventCallback: callback)
 
         XCTAssertEqual(pusher.connection.globalChannel?.globalCallbacks.count, 1, "the global channel should have 1 bound callback")
         pusher.unbind(callbackId: callBackId)

--- a/Tests/PusherTopLevelAPITests.swift
+++ b/Tests/PusherTopLevelAPITests.swift
@@ -119,7 +119,7 @@ class PusherTopLevelApiTests: XCTestCase {
     func testSubscriptionSucceededEventSentToGlobalChannelViaEventCallback() {
         pusher.connect()
         let callback = { (event: PusherEvent) -> Void in
-            if event.name == "pusher:subscription_succeeded" {
+            if event.eventName == "pusher:subscription_succeeded" {
                 self.socket.appendToCallbackCheckString("globalCallbackCalled")
             }
         }

--- a/Tests/PusherTopLevelAPITests.swift
+++ b/Tests/PusherTopLevelAPITests.swift
@@ -119,7 +119,7 @@ class PusherTopLevelApiTests: XCTestCase {
     func testSubscriptionSucceededEventSentToGlobalChannelViaEventCallback() {
         pusher.connect()
         let callback = { (event: PusherEvent) -> Void in
-            if event.event == "pusher:subscription_succeeded" {
+            if event.name == "pusher:subscription_succeeded" {
                 self.socket.appendToCallbackCheckString("globalCallbackCalled")
             }
         }

--- a/Tests/PusherTopLevelAPITests.swift
+++ b/Tests/PusherTopLevelAPITests.swift
@@ -105,6 +105,17 @@ class PusherTopLevelApiTests: XCTestCase {
         XCTAssertEqual(socket.callbackCheckString, "globalCallbackCalled")
     }
 
+    func testSubscriptionSucceededEventSentToChannelCallback() {
+        let callback = { (data: Any?) -> Void in
+            self.socket.appendToCallbackCheckString("channelCallbackCalled")
+        }
+        XCTAssertEqual(socket.callbackCheckString, "")
+        let channel = pusher.subscribe("test-channel")
+        let _ = channel.bind(eventName: "pusher:subscription_succeeded", callback: callback)
+        pusher.connect()
+        XCTAssertEqual(socket.callbackCheckString, "channelCallbackCalled")
+    }
+
     /* authenticated channels */
 
     func testAuthenticatedChannelIsSetupCorrectly() {


### PR DESCRIPTION
### Description of the pull request
Adding new `bind` methods so that the `user_id` (and other event properties) can be accessed in the callback via a `PusherEvent`.

#### Why is the change necessary?
It isn't currently possible to access any extra properties sent in the event object.
