### PR TITLE
Add doc about keeping a strong reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,6 @@ Where `"Authorization"` and `"myToken"` are the field and value your server is e
 
 A Websocket connection is established by providing your API key to the constructor function:
 
-**Important:** You must keep a strong reference to the `Pusher` client. You could achieve that by making `pusher` a property of your app delegate, for example.
-
 #### Swift
 
 ```swift
@@ -329,6 +327,8 @@ Pusher *pusher = [[Pusher alloc] initWithAppKey:@"YOUR_APP_KEY"];
 ```
 
 This returns a client object which can then be used to subscribe to channels and then calling `connect()` triggers the connection process to start.
+
+**Important:** You must keep a strong reference to the `Pusher` client. You could achieve that by making `pusher` a property of your app delegate, for example.
 
 You can also set a `userDataFetcher` on the connection object.
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ Where `"Authorization"` and `"myToken"` are the field and value your server is e
 
 A Websocket connection is established by providing your API key to the constructor function:
 
+**Important:** You must keep a strong reference to the `Pusher` client. You could achieve that by making `pusher` a property of your app delegate, for example.
+
 #### Swift
 
 ```swift


### PR DESCRIPTION
### Description of the pull request
Users must keep a strong reference to the client. If they don't then the client will be deallocated and it will cease to function.