### PR TITLE
Fix compilation warning

### DIFF
--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -221,7 +221,7 @@ import CryptoSwift
 
         - parameter event:       The name of the event
         - parameter data:        The data to be stringified and sent
-        - parameter channelName: The name of the channel
+        - parameter channel: The name of the channel
     */
     open func sendEvent(event: String, data: Any, channel: PusherChannel? = nil) {
         if event.components(separatedBy: "-")[0] == "client" {


### PR DESCRIPTION
### Description of the pull request

Warning was `Parameter 'channelName' not found in the function declaration`

#### Why is the change necessary?

One less warning in Xcode's issues pane :)