### PR TITLE
Correct parameter name in documentation comment

### DIFF
--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -219,8 +219,8 @@ import CryptoSwift
         and data, or calls a client event to be sent if the event is prefixed with
         "client"
 
-        - parameter event:       The name of the event
-        - parameter data:        The data to be stringified and sent
+        - parameter event:   The name of the event
+        - parameter data:    The data to be stringified and sent
         - parameter channel: The name of the channel
     */
     open func sendEvent(event: String, data: Any, channel: PusherChannel? = nil) {
@@ -236,9 +236,9 @@ import CryptoSwift
     /**
         Sends a client event with the given event, data, and channel name
 
-        - parameter event:       The name of the event
-        - parameter data:        The data to be stringified and sent
-        - parameter channelName: The name of the channel
+        - parameter event:   The name of the event
+        - parameter data:    The data to be stringified and sent
+        - parameter channel: The name of the channel
     */
     fileprivate func sendClientEvent(event: String, data: Any, channel: PusherChannel?) {
         if let channel = channel {


### PR DESCRIPTION
#232 corrected a parameter in a documentation comment. This PR updates the formatting of the other parameters and updates the `channel` parameter for the function below, which has the same issue.