### PR TITLE
Add Swift Package Manager to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ github "pusher/pusher-websocket-swift"
 
 ### Swift Package Manager
 
-To integrate PusherSwift into your project using [Swift Package Manager](https://swift.org/package-manager/), you can add it as a dependency using Xcode (11 and above) – see [docs](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app). The package repository URL is:
+To integrate PusherSwift into your project using [Swift Package Manager](https://swift.org/package-manager/), you can add the library as a dependency using Xcode (11 and above) – see the [docs](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app). The package repository URL is:
 
 ```bash
 https://github.com/pusher/pusher-websocket-swift.git

--- a/README.md
+++ b/README.md
@@ -108,6 +108,22 @@ To integrate PusherSwift into your Xcode project using Carthage, specify it in y
 github "pusher/pusher-websocket-swift"
 ```
 
+### Swift Package Manager
+
+To integrate PusherSwift into your project using [Swift Package Manager](https://swift.org/package-manager/), you can add it as a dependency using Xcode (11 and above) – see [docs](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app). The package repository URL is:
+
+```bash
+https://github.com/pusher/pusher-websocket-swift.git
+```
+
+Alternatively, you can add PusherSwift as a dependency in your `Package.swift` file:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "7.2.0")
+]
+```
+
 ## Configuration
 
 There are a number of configuration parameters which can be set for the Pusher client. For Swift usage they are:

--- a/README.md
+++ b/README.md
@@ -119,9 +119,16 @@ https://github.com/pusher/pusher-websocket-swift.git
 Alternatively, you can add PusherSwift as a dependency in your `Package.swift` file:
 
 ```swift
+//...
 dependencies: [
     .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "7.2.0")
+],
+targets: [
+    .target(
+        name: "YourAppTarget",
+        dependencies: ["PusherSwift"])
 ]
+//...
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -116,19 +116,28 @@ To integrate PusherSwift into your project using [Swift Package Manager](https:/
 https://github.com/pusher/pusher-websocket-swift.git
 ```
 
-Alternatively, you can add PusherSwift as a dependency in your `Package.swift` file:
+Alternatively, you can add PusherSwift as a dependency in your `Package.swift` file. For example:
 
 ```swift
-// ...
-dependencies: [
-    .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "7.2.0")
-],
-targets: [
-    .target(
-        name: "YourAppTarget",
-        dependencies: ["PusherSwift"])
-]
-// ...
+// swift-tools-version:5.1
+import PackageDescription
+
+let package = Package(
+    name: "YourPackage",
+    products: [
+        .library(
+            name: "YourPackage",
+            targets: ["YourPackage"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "7.1.1"),
+    ],
+    targets: [
+        .target(
+            name: "YourPackage",
+            dependencies: ["PusherSwift"]),
+    ]
+)
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ let package = Package(
             targets: ["YourPackage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "7.1.1"),
+        .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "7.2.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ https://github.com/pusher/pusher-websocket-swift.git
 Alternatively, you can add PusherSwift as a dependency in your `Package.swift` file:
 
 ```swift
-//...
+// ...
 dependencies: [
     .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "7.2.0")
 ],
@@ -128,7 +128,7 @@ targets: [
         name: "YourAppTarget",
         dependencies: ["PusherSwift"])
 ]
-//...
+// ...
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ github "pusher/pusher-websocket-swift"
 
 ### Swift Package Manager
 
-To integrate PusherSwift into your project using [Swift Package Manager](https://swift.org/package-manager/), you can add the library as a dependency using Xcode (11 and above) – see the [docs](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app). The package repository URL is:
+To integrate PusherSwift into your project using [Swift Package Manager](https://swift.org/package-manager/), you can add the library as a dependency in Xcode (11 and above) – see the [docs](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app). The package repository URL is:
 
 ```bash
 https://github.com/pusher/pusher-websocket-swift.git


### PR DESCRIPTION
We have added support for Swift Package Manager so this PR adds a section to the docs explaining how to import PusherSwift using Swift Package Manager.