### PR TITLE
Update CryptoSwift to 1.1.3 and Reachability.swift to 4.3.1 to quiet build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Update CryptoSwift to 1.1.3 and Reachability.swift to 4.3.1 to quiet build warnings ([@marcetcheverry](https://github.com/marcetcheverry)).
+- Update Reachability.swift to 4.3.1 to quiet build warnings ([@marcetcheverry](https://github.com/marcetcheverry)).
 
 ## [7.2.0](https://github.com/pusher/pusher-websocket-swift/compare/7.1.0...7.2.0) - 2019-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/pusher-websocket-swift/compare/7.2.0...HEAD)
 
+### Fixed
+
+- Update CryptoSwift to 1.1.3 and Reachability.swift to 4.3.1 to quiet build warnings ([@marcetcheverry](https://github.com/marcetcheverry)).
+
 ## [7.2.0](https://github.com/pusher/pusher-websocket-swift/compare/7.1.0...7.2.0) - 2019-10-18
 
 ### Added

--- a/Cartfile
+++ b/Cartfile
@@ -3,6 +3,6 @@
 # PusherSwift has target "8.0" therefore the version in this
 # file can't match PusherSwift's Podspec's minimum CryptoSwift
 # version currently.
-github "krzyzanowskim/CryptoSwift" ~> 0.15.0
-github "ashleymills/Reachability.swift" == 4.3.0
+github "krzyzanowskim/CryptoSwift" ~> 1.1.3
+github "ashleymills/Reachability.swift" == 4.3.1
 github "daltoniam/Starscream" == 3.0.6

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "ashleymills/Reachability.swift" "v4.3.0"
+github "ashleymills/Reachability.swift" "v4.3.1"
 github "daltoniam/Starscream" "3.0.6"
-github "krzyzanowskim/CryptoSwift" "0.15.0"
+github "krzyzanowskim/CryptoSwift" "1.1.3"

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,8 @@ let package = Package(
         .library(name: "PusherSwift", targets: ["PusherSwift"])
     ],
     dependencies: [
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "0.9.0")),
-        .package(url: "https://github.com/ashleymills/Reachability.swift.git", .exact("4.3.0")),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "1.1.3")),
+        .package(url: "https://github.com/ashleymills/Reachability.swift.git", .exact("4.3.1")),
         .package(url: "https://github.com/daltoniam/Starscream.git", .exact("3.0.6")),
     ],
     targets: [

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.source_files  = 'Sources/*.swift'
 
-  s.dependency 'CryptoSwift', '~> 0.9'
-  s.dependency 'ReachabilitySwift', '4.3.0'
+  s.dependency 'CryptoSwift', '~> 1.1.3'
+  s.dependency 'ReachabilitySwift', '4.3.1'
   s.dependency 'Starscream', '~> 3.0.5'
 
   s.ios.deployment_target = '8.0'


### PR DESCRIPTION
### Description of the pull request
Update `CryptoSwift` to `1.1.3` and `Reachability.swift` to `4.3.1` to quiet build warnings.

#### Why is the change necessary?
Xcode 11.2.1 show several build warnings with these third party libraries.

See https://github.com/pusher/pusher-websocket-swift/issues/238

While `Reachability.swift` `4.3.1` is not the latest released version, it is the most recent one that builds without further changes to the codebase.

Let me know if I need to make any adjustments to the `CHANGELOG` or the `Carthage` and `SwiftPM` files, I tried to keep changes to a minimum.