### PR TITLE
Help readers notice that we have other package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ What else would you want? Head over to one of our example apps:
 ## Table of Contents
 
 - [Installation](#installation)
+  - [CocoaPods](#cocoapods)
+  - [Carthage](#carthage)
+  - [Swift Package Manager](#swift-package-manager)
 - [Configuration](#configuration)
 - [Connection](#connection)
   - [Connection delegate](#connection-delegate)


### PR DESCRIPTION
#### Why is the change necessary?

Noticed in testing that people jump straight to Cocoapods without realizing we have other (perhaps preferred) options.