### PR TITLE
Replace CryptoSwift with CommonCrypto HMAC functions

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,8 +1,2 @@
-# CryptoSwift versions 0.9 - 0.10 inclusive have iOS deployment
-# target "9.0" set in the Xcode project (but not in the Podspec).
-# PusherSwift has target "8.0" therefore the version in this
-# file can't match PusherSwift's Podspec's minimum CryptoSwift
-# version currently.
-github "krzyzanowskim/CryptoSwift" ~> 0.15.0
 github "ashleymills/Reachability.swift" == 4.3.0
 github "daltoniam/Starscream" == 3.0.6

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,2 @@
 github "ashleymills/Reachability.swift" "v4.3.0"
 github "daltoniam/Starscream" "3.0.6"
-github "krzyzanowskim/CryptoSwift" "0.15.0"

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "CryptoSwift",
-        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
-        "state": {
-          "branch": null,
-          "revision": "5da70ba744d58d772201f03600eb16c53197652d",
-          "version": "0.15.0"
-        }
-      },
-      {
         "package": "Reachability",
         "repositoryURL": "https://github.com/ashleymills/Reachability.swift.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,6 @@ let package = Package(
         .library(name: "PusherSwift", targets: ["PusherSwift"])
     ],
     dependencies: [
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "0.9.0")),
         .package(url: "https://github.com/ashleymills/Reachability.swift.git", .exact("4.3.0")),
         .package(url: "https://github.com/daltoniam/Starscream.git", .exact("3.0.6")),
     ],
@@ -16,7 +15,6 @@ let package = Package(
         .target(
             name: "PusherSwift",
             dependencies: [
-                "CryptoSwift",
                 "Reachability",
                 "Starscream",
             ],

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -12,7 +12,6 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.source_files  = 'Sources/*.swift'
 
-  s.dependency 'CryptoSwift', '~> 0.9'
   s.dependency 'ReachabilitySwift', '4.3.0'
   s.dependency 'Starscream', '~> 3.0.5'
 

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		E24D0AA522D798C8009DE31B /* PusherEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24D0AA422D798C8009DE31B /* PusherEvent.swift */; };
 		E29A4CBC2301BA31000BC499 /* PusherEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29A4CBB2301BA31000BC499 /* PusherEventTests.swift */; };
 		E2CFE43122D79CA7004187C3 /* PusherParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2CFE43022D79CA7004187C3 /* PusherParser.swift */; };
+		E2F40FA523ED782B00985C40 /* PusherCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F40FA423ED782B00985C40 /* PusherCrypto.swift */; };
+		E2F40FA723ED79BC00985C40 /* PusherCryptoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F40FA623ED79BC00985C40 /* PusherCryptoTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +84,8 @@
 		E24D0AA422D798C8009DE31B /* PusherEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEvent.swift; sourceTree = "<group>"; };
 		E29A4CBB2301BA31000BC499 /* PusherEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEventTests.swift; sourceTree = "<group>"; };
 		E2CFE43022D79CA7004187C3 /* PusherParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherParser.swift; sourceTree = "<group>"; };
+		E2F40FA423ED782B00985C40 /* PusherCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherCrypto.swift; sourceTree = "<group>"; };
+		E2F40FA623ED79BC00985C40 /* PusherCryptoTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherCryptoTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -141,6 +145,7 @@
 				33831CD61A9CFFF200B124F1 /* PusherSwift.h */,
 				E24D0AA422D798C8009DE31B /* PusherEvent.swift */,
 				E2498292231E612700CFBBD6 /* PusherError.swift */,
+				E2F40FA423ED782B00985C40 /* PusherCrypto.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -170,6 +175,7 @@
 				33BB99661D21226C00B25C2A /* PusherTopLevelAPITests.swift */,
 				33BB99671D21226C00B25C2A /* Info.plist */,
 				E29A4CBB2301BA31000BC499 /* PusherEventTests.swift */,
+				E2F40FA623ED79BC00985C40 /* PusherCryptoTest.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -304,7 +310,6 @@
 			);
 			inputPaths = (
 				Starscream,
-				CryptoSwift,
 				Reachability,
 			);
 			name = "Copy Carthage Frameworks";
@@ -326,6 +331,7 @@
 				E2498293231E612700CFBBD6 /* PusherError.swift in Sources */,
 				E24D0AA522D798C8009DE31B /* PusherEvent.swift in Sources */,
 				3389F56A1CAEDD9100563F49 /* PusherWebsocketDelegate.swift in Sources */,
+				E2F40FA523ED782B00985C40 /* PusherCrypto.swift in Sources */,
 				330D7A6D1CAEDA750032FF2C /* PusherChannel.swift in Sources */,
 				3390D1E81F054D1E00E1944D /* Authorizer.swift in Sources */,
 				3389F5721CAEDDF300563F49 /* PusherChannels.swift in Sources */,
@@ -344,6 +350,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				33BB997A1D21230100B25C2A /* PusherConnectionTests.swift in Sources */,
+				E2F40FA723ED79BC00985C40 /* PusherCryptoTest.swift in Sources */,
 				33BB99791D21230100B25C2A /* PusherClientInitializationTests.swift in Sources */,
 				33BB99771D21230100B25C2A /* PresenceChannelTests.swift in Sources */,
 				33BB997C1D21230100B25C2A /* PusherTopLevelAPITests.swift in Sources */,

--- a/Sources/PusherCrypto.swift
+++ b/Sources/PusherCrypto.swift
@@ -1,0 +1,35 @@
+import Foundation
+import CommonCrypto
+
+struct PusherCrypto {
+
+    /**
+        Generates a SHA256 HMAC digest of the message using the secret
+
+        - returns: The hex encoded MAC string
+    */
+     static func generateSHA256HMAC(secret: String, message: String) -> String {
+        let secretData = Data(secret.utf8)
+        let messageData = Data(message.utf8)
+
+        let algorithm = CCHmacAlgorithm(kCCHmacAlgSHA256)
+        let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
+
+        var digest = Data(count: digestLength)
+
+        _ = digest.withUnsafeMutableBytes { digestBytes in
+            _ = secretData.withUnsafeBytes { secretBytes in
+                _ = messageData.withUnsafeBytes { messageBytes in
+                    CCHmac(algorithm, secretBytes, secretData.count, messageBytes, messageData.count, digestBytes)
+                }
+            }
+        }
+
+        // Data to hex string
+        let signature = digest
+            .map { String(format: "%02x", $0) }
+            .joined()
+
+        return signature
+    }
+}

--- a/Tests/PusherCryptoTest.swift
+++ b/Tests/PusherCryptoTest.swift
@@ -1,0 +1,16 @@
+@testable
+import PusherSwift
+import XCTest
+
+class PusherCryptoTest: XCTestCase {
+    func testHMACGeneratorGeneratesCorrectMAC() {
+        let secret = "mysecret"
+        let message = "{\"user\":\"my user data\"}"
+
+        let digest = PusherCrypto.generateSHA256HMAC(secret: secret, message: message)
+        XCTAssertNotNil(digest)
+
+        let expectedDigest = "7705bb9a7934fe4ceee2325e23750f35752899448c2fe5b064d93326c98fd5b3"
+        XCTAssertEqual(digest, expectedDigest)
+    }
+}

--- a/Tests/PusherCryptoTest.swift
+++ b/Tests/PusherCryptoTest.swift
@@ -8,7 +8,6 @@ class PusherCryptoTest: XCTestCase {
         let message = "{\"user\":\"my user data\"}"
 
         let digest = PusherCrypto.generateSHA256HMAC(secret: secret, message: message)
-        XCTAssertNotNil(digest)
 
         let expectedDigest = "7705bb9a7934fe4ceee2325e23750f35752899448c2fe5b064d93326c98fd5b3"
         XCTAssertEqual(digest, expectedDigest)

--- a/iOS Example Obj-C/iOS Example Obj-C.xcodeproj/project.pbxproj
+++ b/iOS Example Obj-C/iOS Example Obj-C.xcodeproj/project.pbxproj
@@ -192,7 +192,6 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/../Carthage/Build/iOS/CryptoSwift.framework",
 				"$(SRCROOT)/../Carthage/Build/iOS/Reachability.framework",
 				"$(SRCROOT)/../Carthage/Build/iOS/Starscream.framework",
 			);

--- a/iOS Example Swift/iOS Example Swift.xcodeproj/project.pbxproj
+++ b/iOS Example Swift/iOS Example Swift.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		335AD5AA20569C3C000D4D08 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 335AD5A620569C3B000D4D08 /* CryptoSwift.framework */; };
 		335AD5AC20569C3C000D4D08 /* Reachability.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 335AD5A820569C3B000D4D08 /* Reachability.framework */; };
 		335AD5B220569F14000D4D08 /* PusherSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 33CC82EA1D7F16A8003B699F /* PusherSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		33831CC21A9CFCDB00B124F1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33831CBE1A9CFCDB00B124F1 /* AppDelegate.swift */; };
@@ -63,7 +62,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				33E94E7620766DBE0005399D /* Starscream.framework in Frameworks */,
-				335AD5AA20569C3C000D4D08 /* CryptoSwift.framework in Frameworks */,
 				335AD5AC20569C3C000D4D08 /* Reachability.framework in Frameworks */,
 				33CC82EB1D7F16A8003B699F /* PusherSwift.framework in Frameworks */,
 			);
@@ -208,7 +206,6 @@
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/../Carthage/Build/iOS/CryptoSwift.framework",
 				"$(SRCROOT)/../Carthage/Build/iOS/Reachability.framework",
 				"$(SRCROOT)/../Carthage/Build/iOS/Starscream.framework",
 			);


### PR DESCRIPTION
Currently we use CryptoSwift to generate a HMAC when users are using the ".inline" auth method for testing. CryptoSwift is a large library and takes a long time to compile. Furthermore, it is desirable to have fewer dependencies because it is difficult to manage multiple dependencies across the multiple package managers that we support.

This PR removes CryptoSwift and instead uses the `CommonCrypto` APIs. 
