### PR TITLE
E2E Decrypt

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -6,3 +6,4 @@
 github "krzyzanowskim/CryptoSwift" ~> 0.15.0
 github "ashleymills/Reachability.swift" == 4.3.0
 github "daltoniam/Starscream" == 3.0.6
+github "jedisct1/swift-sodium" == 0.8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
 github "ashleymills/Reachability.swift" "v4.3.0"
 github "daltoniam/Starscream" "3.0.6"
+github "jedisct1/swift-sodium" "0.8.0"
 github "krzyzanowskim/CryptoSwift" "0.15.0"

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.dependency 'CryptoSwift', '~> 0.9'
   s.dependency 'ReachabilitySwift', '4.3.0'
   s.dependency 'Starscream', '~> 3.0.5'
+  s.dependency 'Sodium', '~> 0.8.0'
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		33BB997C1D21230100B25C2A /* PusherTopLevelAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BB99661D21226C00B25C2A /* PusherTopLevelAPITests.swift */; };
 		33C1FD6F1D81BFC300921AD7 /* ObjectiveC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */; };
 		33C40CB91C1DFC9C008A54E3 /* PusherSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 33831CD61A9CFFF200B124F1 /* PusherSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		730EECB724290BE700F0EB73 /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 730EECB624290BE700F0EB73 /* Sodium.framework */; };
 		E2498293231E612700CFBBD6 /* PusherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2498292231E612700CFBBD6 /* PusherError.swift */; };
 		E24D0AA522D798C8009DE31B /* PusherEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24D0AA422D798C8009DE31B /* PusherEvent.swift */; };
 		E29A4CBC2301BA31000BC499 /* PusherEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29A4CBB2301BA31000BC499 /* PusherEventTests.swift */; };
@@ -78,6 +79,7 @@
 		33BB99661D21226C00B25C2A /* PusherTopLevelAPITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PusherTopLevelAPITests.swift; path = ../Tests/PusherTopLevelAPITests.swift; sourceTree = "<group>"; };
 		33BB99671D21226C00B25C2A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
 		33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveC.swift; sourceTree = "<group>"; };
+		730EECB624290BE700F0EB73 /* Sodium.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sodium.framework; path = Carthage/Build/iOS/Sodium.framework; sourceTree = "<group>"; };
 		E2498292231E612700CFBBD6 /* PusherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherError.swift; sourceTree = "<group>"; };
 		E24D0AA422D798C8009DE31B /* PusherEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEvent.swift; sourceTree = "<group>"; };
 		E29A4CBB2301BA31000BC499 /* PusherEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEventTests.swift; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				730EECB724290BE700F0EB73 /* Sodium.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -177,6 +180,7 @@
 		42D29A655054030A9B238900 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				730EECB624290BE700F0EB73 /* Sodium.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -211,6 +215,7 @@
 				33831C861A9CF61600B124F1 /* Headers */,
 				33831C871A9CF61600B124F1 /* Resources */,
 				50355EA8A07B4B8038A4DDF1 /* Frameworks */,
+				730EECB52429067100F0EB73 /* Copy Carthage Dependencies */,
 			);
 			buildRules = (
 			);
@@ -308,6 +313,25 @@
 				Reachability,
 			);
 			name = "Copy Carthage Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "case \"$PLATFORM_NAME\" in\nmacosx) plat=Mac;;\niphone*) plat=iOS;;\nwatch*) plat=watchOS;;\ntv*) plat=tvOS;;\nappletv*) plat=tvOS;;\n*) echo \"error: Unknown PLATFORM_NAME: $PLATFORM_NAME\"; exit 1;;\nesac\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nframework=$(basename \"${!VAR}\")\nexport SCRIPT_INPUT_FILE_$n=\"$SRCROOT\"/Carthage/Build/$plat/\"$framework\".framework\ndone\n\n/usr/local/bin/carthage copy-frameworks || exit\n\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nsource=${!VAR}.dSYM\ndest=${BUILT_PRODUCTS_DIR}/$(basename \"$source\")\nditto \"$source\" \"$dest\" || exit\ndone\n";
+		};
+		730EECB52429067100F0EB73 /* Copy Carthage Dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				Sodium,
+			);
+			name = "Copy Carthage Dependencies";
+			outputFileListPaths = (
+			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -478,6 +502,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -544,6 +572,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -235,7 +235,6 @@
 				33831C861A9CF61600B124F1 /* Headers */,
 				33831C871A9CF61600B124F1 /* Resources */,
 				50355EA8A07B4B8038A4DDF1 /* Frameworks */,
-				730EECB52429067100F0EB73 /* Copy Carthage Dependencies */,
 			);
 			buildRules = (
 			);
@@ -333,25 +332,6 @@
 				Reachability,
 			);
 			name = "Copy Carthage Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "case \"$PLATFORM_NAME\" in\nmacosx) plat=Mac;;\niphone*) plat=iOS;;\nwatch*) plat=watchOS;;\ntv*) plat=tvOS;;\nappletv*) plat=tvOS;;\n*) echo \"error: Unknown PLATFORM_NAME: $PLATFORM_NAME\"; exit 1;;\nesac\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nframework=$(basename \"${!VAR}\")\nexport SCRIPT_INPUT_FILE_$n=\"$SRCROOT\"/Carthage/Build/$plat/\"$framework\".framework\ndone\n\n/usr/local/bin/carthage copy-frameworks || exit\n\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nsource=${!VAR}.dSYM\ndest=${BUILT_PRODUCTS_DIR}/$(basename \"$source\")\nditto \"$source\" \"$dest\" || exit\ndone\n";
-		};
-		730EECB52429067100F0EB73 /* Copy Carthage Dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				Sodium,
-			);
-			name = "Copy Carthage Dependencies";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		33C1FD6F1D81BFC300921AD7 /* ObjectiveC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */; };
 		33C40CB91C1DFC9C008A54E3 /* PusherSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 33831CD61A9CFFF200B124F1 /* PusherSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		730EECB724290BE700F0EB73 /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 730EECB624290BE700F0EB73 /* Sodium.framework */; };
+		736E53F5242A378B0052CC1B /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736E53F3242A35D90052CC1B /* String+Extensions.swift */; };
+		736E53F7242A45AC0052CC1B /* XCTest+Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736E53F6242A45AC0052CC1B /* XCTest+Assertions.swift */; };
+		736E53FA242A4EE00052CC1B /* PusherKeyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736E53F8242A4DE60052CC1B /* PusherKeyProvider.swift */; };
+		736E53FD242A55230052CC1B /* PusherKeyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736E53FC242A55230052CC1B /* PusherKeyProvider.swift */; };
 		E2498293231E612700CFBBD6 /* PusherError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2498292231E612700CFBBD6 /* PusherError.swift */; };
 		E24D0AA522D798C8009DE31B /* PusherEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24D0AA422D798C8009DE31B /* PusherEvent.swift */; };
 		E29A4CBC2301BA31000BC499 /* PusherEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29A4CBB2301BA31000BC499 /* PusherEventTests.swift */; };
@@ -80,6 +84,10 @@
 		33BB99671D21226C00B25C2A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
 		33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveC.swift; sourceTree = "<group>"; };
 		730EECB624290BE700F0EB73 /* Sodium.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sodium.framework; path = Carthage/Build/iOS/Sodium.framework; sourceTree = "<group>"; };
+		736E53F3242A35D90052CC1B /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		736E53F6242A45AC0052CC1B /* XCTest+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Assertions.swift"; sourceTree = "<group>"; };
+		736E53F8242A4DE60052CC1B /* PusherKeyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherKeyProvider.swift; sourceTree = "<group>"; };
+		736E53FC242A55230052CC1B /* PusherKeyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherKeyProvider.swift; sourceTree = "<group>"; };
 		E2498292231E612700CFBBD6 /* PusherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherError.swift; sourceTree = "<group>"; };
 		E24D0AA422D798C8009DE31B /* PusherEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEvent.swift; sourceTree = "<group>"; };
 		E29A4CBB2301BA31000BC499 /* PusherEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEventTests.swift; sourceTree = "<group>"; };
@@ -144,6 +152,7 @@
 				33831CD61A9CFFF200B124F1 /* PusherSwift.h */,
 				E24D0AA422D798C8009DE31B /* PusherEvent.swift */,
 				E2498292231E612700CFBBD6 /* PusherError.swift */,
+				736E53F8242A4DE60052CC1B /* PusherKeyProvider.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -160,6 +169,7 @@
 		33BB995C1D21225B00B25C2A /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				736E53FB242A55110052CC1B /* Doubles */,
 				33BB995D1D21226C00B25C2A /* AuthenticationTests.swift */,
 				3342F3BB1D808AC500C0296E /* ClientEventTests.swift */,
 				33BB995F1D21226C00B25C2A /* Helpers.swift */,
@@ -173,6 +183,8 @@
 				33BB99661D21226C00B25C2A /* PusherTopLevelAPITests.swift */,
 				33BB99671D21226C00B25C2A /* Info.plist */,
 				E29A4CBB2301BA31000BC499 /* PusherEventTests.swift */,
+				736E53F3242A35D90052CC1B /* String+Extensions.swift */,
+				736E53F6242A45AC0052CC1B /* XCTest+Assertions.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -183,6 +195,14 @@
 				730EECB624290BE700F0EB73 /* Sodium.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		736E53FB242A55110052CC1B /* Doubles */ = {
+			isa = PBXGroup;
+			children = (
+				736E53FC242A55230052CC1B /* PusherKeyProvider.swift */,
+			);
+			path = Doubles;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -358,6 +378,7 @@
 				3389F57A1CAEDEC800563F49 /* PusherClientOptions.swift in Sources */,
 				3389F56E1CAEDDD800563F49 /* PusherPresenceChannel.swift in Sources */,
 				33C1FD6F1D81BFC300921AD7 /* ObjectiveC.swift in Sources */,
+				736E53FA242A4EE00052CC1B /* PusherKeyProvider.swift in Sources */,
 				3390D1E61F054D0400E1944D /* AuthRequestBuilderProtocol.swift in Sources */,
 				330D7A6A1CAEDA6C0032FF2C /* PusherSwift.swift in Sources */,
 			);
@@ -368,10 +389,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				33BB997A1D21230100B25C2A /* PusherConnectionTests.swift in Sources */,
+				736E53F5242A378B0052CC1B /* String+Extensions.swift in Sources */,
 				33BB99791D21230100B25C2A /* PusherClientInitializationTests.swift in Sources */,
 				33BB99771D21230100B25C2A /* PresenceChannelTests.swift in Sources */,
 				33BB997C1D21230100B25C2A /* PusherTopLevelAPITests.swift in Sources */,
+				736E53F7242A45AC0052CC1B /* XCTest+Assertions.swift in Sources */,
 				33BB997B1D21230100B25C2A /* PusherIncomingEventHandlingTests.swift in Sources */,
+				736E53FD242A55230052CC1B /* PusherKeyProvider.swift in Sources */,
 				3342F3BD1D808AC900C0296E /* ClientEventTests.swift in Sources */,
 				33BB99751D21230100B25C2A /* Helpers.swift in Sources */,
 				33BB99731D21230100B25C2A /* AuthenticationTests.swift in Sources */,

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -592,7 +592,7 @@ import CryptoSwift
             "channel": channelName,
             "data": data ?? ""
         ]
-        let event = PusherEvent(jsonObject: json)!
+        let event = PusherEvent(jsonObject: json, keyProvider: keyProvider)!
         DispatchQueue.main.async {
             // TODO: Consider removing in favour of exclusively using delegate
             self.handleEvent(event: event)
@@ -601,6 +601,12 @@ import CryptoSwift
         self.delegate?.failedToSubscribeToChannel?(name: channelName, response: response, data: data, error: error)
     }
 
+    // TODO: this needs to be rethought once the auth call provides the decryptionKey
+    internal var keyProvider: PusherKeyProviding {
+        let decryptionKey = "<ENTER_YOUR_KEY>"
+        return PusherKeyProvider(decryptionKey: decryptionKey)
+    }
+    
     /**
         Handles incoming events and passes them on to be handled by the appropriate function
 

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -21,7 +21,7 @@ open class PusherEvent: NSObject, NSCopying {
     
     /// The data that was passed when the event was triggered.
     public lazy var data: String? = {
-        if self.isEncryptedChannel {
+        if self.isEncryptedChannel && !self.isPusherSystemEvent {
             return self.decryptedString
         }
         return raw["data"] as? String
@@ -32,6 +32,10 @@ open class PusherEvent: NSObject, NSCopying {
 
     @nonobjc private lazy var isEncryptedChannel: Bool = {
         return channelName?.starts(with: "private-encrypted-") ?? false
+    }()
+    
+    @nonobjc private lazy var isPusherSystemEvent: Bool = {
+        return eventName.starts(with: "pusher:") || eventName.starts(with: "pusher_internal:")
     }()
     
     @nonobjc private lazy var decryptedString: String? = {

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -1,26 +1,92 @@
 import Foundation
+import Sodium
 
 @objcMembers
 open class PusherEvent: NSObject, NSCopying {
+    
+    private struct EncryptedData: Decodable {
+        var nonce: String
+        var ciphertext: String
+    }
+    
     /// The JSON object received from the websocket
     @nonobjc internal let raw: [String: Any]
 
     // According to Channels protocol, there is always an event https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
     /// The name of the event.
-    public var eventName: String { return raw["event"] as! String }
+    public lazy var eventName: String = { return raw["event"] as! String }()
+    
     /// The name of the channel that the event was triggered on. Not present in events without an associated channel, e.g. "pusher:error" events relating to the connection.
-    public var channelName: String? { return raw["channel"] as? String }
+    public lazy var channelName: String? = { return raw["channel"] as? String }()
+    
     /// The data that was passed when the event was triggered.
-    public var data: String? { return raw["data"] as? String }
+    public lazy var data: String? = {
+        if self.isEncryptedChannel {
+            return self.decryptedString
+        }
+        return raw["data"] as? String
+    }()
+    
     /// The ID of the user who triggered the event. Only present in client event on presence channels.
-    public var userId: String? { return raw["user_id"] as? String }
+    public lazy var userId: String? = { return raw["user_id"] as? String }()
 
-    @nonobjc internal init?(jsonObject: [String: Any]) {
+    @nonobjc private lazy var isEncryptedChannel: Bool = {
+        return channelName?.starts(with: "private-encrypted-") ?? false
+    }()
+    
+    @nonobjc private lazy var decryptedString: String? = {
+        guard
+            let cipherText = self.cipherText,
+            let secretKey = self.secretKey,
+            let nonce = self.nonce,
+            let decryptedData = sodium.secretBox.open(authenticatedCipherText: cipherText, secretKey: secretKey, nonce: nonce),
+            let decryptedString = String(bytes: decryptedData, encoding: .utf8) else {
+                return nil
+        }
+        return decryptedString
+    }()
+    
+    @nonobjc private lazy var encryptedData: EncryptedData? = {
+        guard let dataAsString = raw["data"] as? String,
+            let dataAsData = dataAsString.data(using: .utf8),
+            let encryptedData = try? JSONDecoder().decode(EncryptedData.self, from: dataAsData) else {
+                return nil
+        }
+        return encryptedData
+    }()
+    
+    @nonobjc private lazy var secretKey: SecretBox.Key? = {
+        guard let keyProvider = self.keyProvider else {
+            return nil
+        }
+        return SecretBox.Key(base64: keyProvider.decryptionKey)
+    }()
+    
+    @nonobjc private lazy var nonce: SecretBox.Nonce? = {
+        guard let encryptedData = self.encryptedData else {
+            return nil
+        }
+        return SecretBox.Nonce(base64: encryptedData.nonce)
+    }()
+    
+    @nonobjc private lazy var cipherText: Bytes? = {
+        guard let encryptedData = self.encryptedData,
+            let decoded_data_cipherText = Data(base64Encoded: encryptedData.ciphertext) else {
+            return nil
+        }
+        return [UInt8](decoded_data_cipherText)
+    }()
+
+    @nonobjc private let sodium = Sodium()
+    @nonobjc private let keyProvider: PusherKeyProviding?
+    
+    @nonobjc internal init?(jsonObject: [String: Any], keyProvider: PusherKeyProviding? = nil) {
         // Every event must have a name
         if !(jsonObject["event"] is String) {
             return nil
         }
         self.raw = jsonObject
+        self.keyProvider = keyProvider
     }
 
     /**
@@ -61,10 +127,10 @@ open class PusherEvent: NSObject, NSCopying {
     @nonobjc internal func copy(withEventName eventName: String) -> PusherEvent {
         var jsonObject = self.raw
         jsonObject["event"] = eventName
-        return PusherEvent(jsonObject: jsonObject)!
+        return PusherEvent(jsonObject: jsonObject, keyProvider: self.keyProvider)!
     }
 
     public func copy(with zone: NSZone? = nil) -> Any {
-        return PusherEvent(jsonObject: self.raw)!
+        return PusherEvent(jsonObject: self.raw, keyProvider: self.keyProvider)!
     }
 }

--- a/Sources/PusherKeyProvider.swift
+++ b/Sources/PusherKeyProvider.swift
@@ -1,0 +1,15 @@
+
+// TODO: this needs to be rethought once the auth call provides the decryptionKey
+
+protocol PusherKeyProviding {
+    var decryptionKey: String { get }
+}
+
+class PusherKeyProvider: PusherKeyProviding {
+    
+    let decryptionKey: String
+    
+    init(decryptionKey: String) {
+        self.decryptionKey = decryptionKey
+    }
+}

--- a/Sources/PusherWebsocketDelegate.swift
+++ b/Sources/PusherWebsocketDelegate.swift
@@ -26,7 +26,7 @@ extension PusherConnection: WebSocketDelegate {
             }
             self.handleError(error: error)
         } else {
-            guard let event = PusherEvent(jsonObject: payload) else {
+            guard let event = PusherEvent(jsonObject: payload, keyProvider: keyProvider) else {
                 self.delegate?.debugLog?(message: "[PUSHER DEBUG] Unable to handle incoming event \(text)")
                 return
             }

--- a/Tests/Doubles/PusherKeyProvider.swift
+++ b/Tests/Doubles/PusherKeyProvider.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import PusherSwift
+
+public class DummyPusherKeyProvider: PusherKeyProviding {
+    
+    private let file: StaticString
+    private let line: UInt
+
+    init(file: StaticString = #file, line: UInt = #line) {
+        self.file = file
+        self.line = line
+    }
+    
+    public var decryptionKey: String {
+        XCTFail("Unexpected call to `\(#function)` on `\(String(describing: self))` object. `Dummy` object's should be never interacted with and only used to satisfy the compiler. Consider using a `Stub` instead", file: file, line: line)
+        return ""
+    }
+    
+}

--- a/Tests/PresenceChannelTests.swift
+++ b/Tests/PresenceChannelTests.swift
@@ -1,5 +1,4 @@
-@testable
-import PusherSwift
+@testable import PusherSwift
 import XCTest
 
 class PusherPresenceChannelTests: XCTestCase {

--- a/Tests/PusherEventTests.swift
+++ b/Tests/PusherEventTests.swift
@@ -1,5 +1,4 @@
-@testable
-import PusherSwift
+@testable import PusherSwift
 import XCTest
 
 class PusherEventTests: XCTestCase {
@@ -133,4 +132,204 @@ class PusherEventTests: XCTestCase {
         XCTAssertTrue(event.property(withKey: "my_null") is NSNull)
     }
 
+    // MARK: Encryption related tests
+    
+    func test_init_unencryptedChannelNameAndUnencryptedPayload_returnsWithUnalteredPayload() {
+        
+        let dataPayload = """
+        {
+            "test": "test string",
+            "and": "another"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "test-event",
+            "channel": "my-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: DummyPusherKeyProvider())
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.channelName, "my-channel")
+            XCTAssertEqual(sut.data, dataPayload)
+        }
+        
+    }
+    
+    func test_init_unencryptedChannelNameAndEncryptedPayload_returnsWithUnalteredPayload() {
+        
+        let dataPayload = """
+        {
+            "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
+            "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "test-event",
+            "channel": "my-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: DummyPusherKeyProvider())
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.channelName, "my-channel")
+            XCTAssertEqual(sut.data, dataPayload)
+        }
+        
+    }
+    
+    func test_init_encryptedChannelNameWithUnncryptedPayload_returnsWithNilPayload() {
+        
+        let dataPayload = """
+        {
+            "test": "test string",
+            "and": "another"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "test-event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: DummyPusherKeyProvider())
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.channelName, "private-encrypted-channel")
+            XCTAssertEqual(sut.data, nil)
+        }
+    }
+    
+    func test_init_encryptedChannelNameWithEncryptedPayloadAndValidKey_returnsWithDecryptedPayload() {
+        
+        let keyProvider = PusherKeyProvider(decryptionKey: "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs=")
+        
+        let dataPayload = """
+        {
+            "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
+            "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "test-event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: keyProvider)
+        
+        let expectedDecryptedPayload = """
+        {
+            "name": "freddy",
+            "message": "hello"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.channelName, "private-encrypted-channel")
+            XCTAssertEqual(sut.data, expectedDecryptedPayload)
+        }
+    }
+    
+    func test_init_encryptedChannelNameWithEncryptedPayloadButBadKey_returnsWithNilPayload() {
+        
+        let keyProvider = PusherKeyProvider(decryptionKey: "00000000000000000000000000000000000000000000")
+        
+        let dataPayload = """
+        {
+            "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
+            "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "test-event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: keyProvider)
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.channelName, "private-encrypted-channel")
+            XCTAssertEqual(sut.data, nil)
+        }
+    }
+    
+    func test_init_encryptedChannelNameWithEncryptedPayloadButBadNonce_returnsWithNilPayload() {
+        
+        let keyProvider = PusherKeyProvider(decryptionKey: "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs=")
+        
+        let dataPayload = """
+        {
+            "nonce": "00000000000000000000000000000000",
+            "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "test-event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: keyProvider)
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.channelName, "private-encrypted-channel")
+            XCTAssertEqual(sut.data, nil)
+        }
+    }
+    
+    func test_init_encryptedChannelNameWithEncryptedPayloadButBadCiphertext_returnsWithNilPayload() {
+        
+        let keyProvider = PusherKeyProvider(decryptionKey: "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs=")
+        
+        let dataPayload = """
+        {
+            "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
+            "ciphertext": "00000000000000000000000000000000000000000000000000000000000000000000"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "test-event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: keyProvider)
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.channelName, "private-encrypted-channel")
+            XCTAssertEqual(sut.data, nil)
+        }
+    }
 }

--- a/Tests/PusherEventTests.swift
+++ b/Tests/PusherEventTests.swift
@@ -134,7 +134,7 @@ class PusherEventTests: XCTestCase {
 
     // MARK: Encryption related tests
     
-    func test_init_unencryptedChannelNameAndUnencryptedPayload_returnsWithUnalteredPayload() {
+    func test_init_unencryptedChannelAndUnencryptedPayload_returnsWithUnalteredPayload() {
         
         let dataPayload = """
         {
@@ -161,7 +161,7 @@ class PusherEventTests: XCTestCase {
         
     }
     
-    func test_init_unencryptedChannelNameAndEncryptedPayload_returnsWithUnalteredPayload() {
+    func test_init_unencryptedChannelAndEncryptedPayload_returnsWithUnalteredPayload() {
         
         let dataPayload = """
         {
@@ -188,7 +188,7 @@ class PusherEventTests: XCTestCase {
         
     }
     
-    func test_init_encryptedChannelNameWithUnncryptedPayload_returnsWithNilPayload() {
+    func test_init_encryptedChannelAndPusherEventAndUnencryptedPayload_returnsWithUnalteredPayload() {
         
         let dataPayload = """
         {
@@ -199,7 +199,7 @@ class PusherEventTests: XCTestCase {
         
         let jsonDict = """
         {
-            "event": "test-event",
+            "event": "pusher:event",
             "channel": "private-encrypted-channel",
             "data": \(dataPayload.escaped)
         }
@@ -208,13 +208,66 @@ class PusherEventTests: XCTestCase {
         let sut = PusherEvent(jsonObject: jsonDict, keyProvider: DummyPusherKeyProvider())
         
         XCTAssertNotNil(sut) { sut in
-            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.eventName, "pusher:event")
+            XCTAssertEqual(sut.channelName, "private-encrypted-channel")
+            XCTAssertEqual(sut.data, dataPayload)
+        }
+    }
+    
+    
+    func test_init_encryptedChannelAndPusherEventAndEncryptedPayload_returnsWithUnalteredPayload() {
+        
+        let dataPayload = """
+        {
+            "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
+            "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "pusher:event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: DummyPusherKeyProvider())
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "pusher:event")
+            XCTAssertEqual(sut.channelName, "private-encrypted-channel")
+            XCTAssertEqual(sut.data, dataPayload)
+        }
+    }
+    
+    func test_init_encryptedChannelAndUserEventAndUnencryptedPayload_returnsWithNilPayload() {
+        
+        let dataPayload = """
+        {
+            "test": "test string",
+            "and": "another"
+        }
+        """.removing(.whitespacesAndNewlines)
+        
+        let jsonDict = """
+        {
+            "event": "user-event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+        
+        let sut = PusherEvent(jsonObject: jsonDict, keyProvider: DummyPusherKeyProvider())
+        
+        XCTAssertNotNil(sut) { sut in
+            XCTAssertEqual(sut.eventName, "user-event")
             XCTAssertEqual(sut.channelName, "private-encrypted-channel")
             XCTAssertEqual(sut.data, nil)
         }
     }
     
-    func test_init_encryptedChannelNameWithEncryptedPayloadAndValidKey_returnsWithDecryptedPayload() {
+    func test_init_encryptedChannelAndUserEventAndEncryptedPayloadAndValidKey_returnsWithDecryptedPayload() {
         
         let keyProvider = PusherKeyProvider(decryptionKey: "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs=")
         
@@ -227,7 +280,7 @@ class PusherEventTests: XCTestCase {
         
         let jsonDict = """
         {
-            "event": "test-event",
+            "event": "user-event",
             "channel": "private-encrypted-channel",
             "data": \(dataPayload.escaped)
         }
@@ -243,13 +296,13 @@ class PusherEventTests: XCTestCase {
         """.removing(.whitespacesAndNewlines)
         
         XCTAssertNotNil(sut) { sut in
-            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.eventName, "user-event")
             XCTAssertEqual(sut.channelName, "private-encrypted-channel")
             XCTAssertEqual(sut.data, expectedDecryptedPayload)
         }
     }
     
-    func test_init_encryptedChannelNameWithEncryptedPayloadButBadKey_returnsWithNilPayload() {
+    func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadKey_returnsWithNilPayload() {
         
         let keyProvider = PusherKeyProvider(decryptionKey: "00000000000000000000000000000000000000000000")
         
@@ -262,7 +315,7 @@ class PusherEventTests: XCTestCase {
         
         let jsonDict = """
         {
-            "event": "test-event",
+            "event": "user-event",
             "channel": "private-encrypted-channel",
             "data": \(dataPayload.escaped)
         }
@@ -271,13 +324,13 @@ class PusherEventTests: XCTestCase {
         let sut = PusherEvent(jsonObject: jsonDict, keyProvider: keyProvider)
         
         XCTAssertNotNil(sut) { sut in
-            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.eventName, "user-event")
             XCTAssertEqual(sut.channelName, "private-encrypted-channel")
             XCTAssertEqual(sut.data, nil)
         }
     }
     
-    func test_init_encryptedChannelNameWithEncryptedPayloadButBadNonce_returnsWithNilPayload() {
+    func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadNonce_returnsWithNilPayload() {
         
         let keyProvider = PusherKeyProvider(decryptionKey: "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs=")
         
@@ -290,7 +343,7 @@ class PusherEventTests: XCTestCase {
         
         let jsonDict = """
         {
-            "event": "test-event",
+            "event": "user-event",
             "channel": "private-encrypted-channel",
             "data": \(dataPayload.escaped)
         }
@@ -299,13 +352,13 @@ class PusherEventTests: XCTestCase {
         let sut = PusherEvent(jsonObject: jsonDict, keyProvider: keyProvider)
         
         XCTAssertNotNil(sut) { sut in
-            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.eventName, "user-event")
             XCTAssertEqual(sut.channelName, "private-encrypted-channel")
             XCTAssertEqual(sut.data, nil)
         }
     }
     
-    func test_init_encryptedChannelNameWithEncryptedPayloadButBadCiphertext_returnsWithNilPayload() {
+    func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadCiphertext_returnsWithNilPayload() {
         
         let keyProvider = PusherKeyProvider(decryptionKey: "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs=")
         
@@ -318,7 +371,7 @@ class PusherEventTests: XCTestCase {
         
         let jsonDict = """
         {
-            "event": "test-event",
+            "event": "user-event",
             "channel": "private-encrypted-channel",
             "data": \(dataPayload.escaped)
         }
@@ -327,9 +380,10 @@ class PusherEventTests: XCTestCase {
         let sut = PusherEvent(jsonObject: jsonDict, keyProvider: keyProvider)
         
         XCTAssertNotNil(sut) { sut in
-            XCTAssertEqual(sut.eventName, "test-event")
+            XCTAssertEqual(sut.eventName, "user-event")
             XCTAssertEqual(sut.channelName, "private-encrypted-channel")
             XCTAssertEqual(sut.data, nil)
         }
     }
+    
 }

--- a/Tests/PusherIncomingEventHandlingTests.swift
+++ b/Tests/PusherIncomingEventHandlingTests.swift
@@ -1,5 +1,4 @@
-@testable
-import PusherSwift
+@testable import PusherSwift
 import XCTest
 
 class HandlingIncomingEventsTests: XCTestCase {

--- a/Tests/PusherTopLevelAPITests.swift
+++ b/Tests/PusherTopLevelAPITests.swift
@@ -1,4 +1,4 @@
-import PusherSwift
+@testable import PusherSwift
 import XCTest
 
 class PusherTopLevelApiTests: XCTestCase {

--- a/Tests/String+Extensions.swift
+++ b/Tests/String+Extensions.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+extension String {
+    
+    public func removing(_ set: CharacterSet) -> String {
+        var newString = self
+        newString.removeAll { char -> Bool in
+            guard let scalar = char.unicodeScalars.first else { return false }
+            return set.contains(scalar)
+        }
+        return newString
+    }
+    
+    public var escaped: String {
+        return self.debugDescription
+    }
+    
+    public func toJsonData(validate: Bool = true, file: StaticString = #file, line: UInt = #line) -> Data {
+        do {
+            let data = try self.toData()
+            if validate {
+                // Verify the string is valid JSON (either a dict or an array) before returning
+                _ = try toJsonAny()
+            }
+            return data
+        } catch {
+            XCTFail("\(error)", file: file, line: line)
+        }
+        return Data()
+    }
+    
+    public func toJsonDict(file: StaticString = #file, line: UInt = #line) -> [String: Any] {
+        do {
+            let json = try toJsonAny()
+
+            guard let jsonDict = json as? [String: Any] else {
+                XCTFail("Not a dictionary", file: file, line: line)
+                return [:]
+            }
+            return jsonDict
+            
+        } catch {
+            XCTFail("\(error)", file: file, line: line)
+        }
+        return [:]
+    }
+    
+    // MARK: - Private methods
+    
+    private func toJsonAny() throws -> Any {
+        return try JSONSerialization.jsonObject(with: self.toData(), options : .allowFragments)
+    }
+    
+    private func toData() throws -> Data {
+        guard let data = self.data(using: .utf8) else {
+            throw JSONError.conversionFailed
+        }
+        return data
+    }
+    
+}
+
+// MARK: - Error handling
+
+enum JSONError: Error {
+    case conversionFailed
+}

--- a/Tests/XCTest+Assertions.swift
+++ b/Tests/XCTest+Assertions.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+private func executeAndAssignResult<T>(_ expression: @autoclosure () throws -> T?, to: inout T?) rethrows {
+    to = try expression()
+}
+
+private func executeAndAssignEquatableResult<T>(_ expression: @autoclosure () throws -> T?, to: inout T?) rethrows where T: Equatable {
+    to = try expression()
+}
+
+public func XCTAssertNotNil<T>(_ expression: @autoclosure () throws -> T?, _ message: String = "", file: StaticString = #file, line: UInt = #line, also validateResult: (T) -> Void) {
+    
+    var result: T?
+    
+    XCTAssertNoThrow(try executeAndAssignResult(expression, to: &result), message, file: file, line: line)
+    XCTAssertNotNil(result, message, file: file, line: line)
+    
+    if let result = result {
+        validateResult(result)
+    }
+}

--- a/iOS Example Obj-C/iOS Example Obj-C.xcodeproj/project.pbxproj
+++ b/iOS Example Obj-C/iOS Example Obj-C.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 				"$(SRCROOT)/../Carthage/Build/iOS/CryptoSwift.framework",
 				"$(SRCROOT)/../Carthage/Build/iOS/Reachability.framework",
 				"$(SRCROOT)/../Carthage/Build/iOS/Starscream.framework",
+				"$(SRCROOT)/../Carthage/Build/iOS/Sodium.framework",
 			);
 			name = "Copy Carthage Frameworks";
 			outputFileListPaths = (

--- a/iOS Example Swift/iOS Example Swift.xcodeproj/project.pbxproj
+++ b/iOS Example Swift/iOS Example Swift.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		33831CC51A9CFCDB00B124F1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33831CC11A9CFCDB00B124F1 /* ViewController.swift */; };
 		33CC82EB1D7F16A8003B699F /* PusherSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CC82EA1D7F16A8003B699F /* PusherSwift.framework */; };
 		33E94E7620766DBE0005399D /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 335AD5A920569C3B000D4D08 /* Starscream.framework */; };
+		7327825A242BED6F00906123 /* Sodium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73278259242BED6F00906123 /* Sodium.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,7 +48,6 @@
 		335AD5A820569C3B000D4D08 /* Reachability.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Reachability.framework; path = ../Carthage/Build/iOS/Reachability.framework; sourceTree = "<group>"; };
 		335AD5A920569C3B000D4D08 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = ../Carthage/Build/iOS/Starscream.framework; sourceTree = "<group>"; };
 		335AD5AF20569DC3000D4D08 /* Carthage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Carthage.xcconfig; sourceTree = "<group>"; };
-		3373BF4C2068F201005A61BE /* StarscreamFork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StarscreamFork.framework; path = ../Carthage/Build/iOS/StarscreamFork.framework; sourceTree = "<group>"; };
 		33831C5E1A9CEEE900B124F1 /* iOS Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		33831CBC1A9CFCD000B124F1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "iOS Example Swift/Info.plist"; sourceTree = SOURCE_ROOT; };
 		33831CBE1A9CFCDB00B124F1 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = "iOS Example Swift/AppDelegate.swift"; sourceTree = SOURCE_ROOT; };
@@ -55,6 +55,7 @@
 		33831CC01A9CFCDB00B124F1 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = Main.storyboard; path = "iOS Example Swift/Main.storyboard"; sourceTree = SOURCE_ROOT; };
 		33831CC11A9CFCDB00B124F1 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = "iOS Example Swift/ViewController.swift"; sourceTree = SOURCE_ROOT; };
 		33CC82EA1D7F16A8003B699F /* PusherSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PusherSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		73278259242BED6F00906123 /* Sodium.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Sodium.framework; path = ../Carthage/Build/iOS/Sodium.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,6 +67,7 @@
 				335AD5AA20569C3C000D4D08 /* CryptoSwift.framework in Frameworks */,
 				335AD5AC20569C3C000D4D08 /* Reachability.framework in Frameworks */,
 				33CC82EB1D7F16A8003B699F /* PusherSwift.framework in Frameworks */,
+				7327825A242BED6F00906123 /* Sodium.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -113,10 +115,10 @@
 		E0B29E04C3C064CEE6120CF2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				3373BF4C2068F201005A61BE /* StarscreamFork.framework */,
 				335AD5A620569C3B000D4D08 /* CryptoSwift.framework */,
 				335AD5A820569C3B000D4D08 /* Reachability.framework */,
 				335AD5A920569C3B000D4D08 /* Starscream.framework */,
+				73278259242BED6F00906123 /* Sodium.framework */,
 				33CC82EA1D7F16A8003B699F /* PusherSwift.framework */,
 			);
 			name = Frameworks;
@@ -211,6 +213,7 @@
 				"$(SRCROOT)/../Carthage/Build/iOS/CryptoSwift.framework",
 				"$(SRCROOT)/../Carthage/Build/iOS/Reachability.framework",
 				"$(SRCROOT)/../Carthage/Build/iOS/Starscream.framework",
+				"$(SRCROOT)/../Carthage/Build/iOS/Sodium.framework",
 			);
 			name = "Copy Carthage Frameworks";
 			outputPaths = (


### PR DESCRIPTION
### Description of the pull request

- Added Carthage and `Swift-Sodium` dependency to main project target
-  Implemented one half of E2E encryption. This part decrypts the payload from an event but at present its necessary to hardcode your decryption key which in future will be provided in the auth response from the server.
- Switched some of the computed properties on `PusherEvent` to be `lazy` loaded so they aren't repeatedly computed and performance is improved.
- Added additional `PusherEventTests` to cover decryption.

#### Why is the change necessary?
- So that the SDK ultimately supports E2E encryption

#### Whats Outstanding?
- The parts of the code where things integrate with the auth call.  I have added a couple of `TODO` s that hopefully cover this.

#### How to See It Working in the Demo App
(This assumes you have a server setup and running somewhere already)

1.  Update `iOS Example Swift/ViewController.swift` with the following...
```
        let pusherHost = PusherHost.cluster("eu")
        let pusherClientOptions = PusherClientOptions(authMethod: .inline(secret: "<YOUR_SECRET>"), host: pusherHost)
        pusher = Pusher(key: "<YOUR_KEY>", options: pusherClientOptions)
```
```
        let myChannel = pusher.subscribe("private-encrypted-<YOUR-CHANNEL>")
```
2. Update `Sources/PusherConnection.swift` hardcoding your decryptionKey here...
```
    internal var keyProvider: PusherKeyProviding {
        let decryptionKey = "<ENTER_YOUR_KEY>"
        return PusherKeyProvider(decryptionKey: decryptionKey)
    }
```
3.  Run the `iOS Example` scheme onto a simulator.