### PR TITLE
Store shared secret for private encrypted channels

### DIFF
--- a/Sources/PusherKeyProvider.swift
+++ b/Sources/PusherKeyProvider.swift
@@ -1,6 +1,4 @@
 
-// TODO: this needs to be rethought once the auth call provides the decryptionKey
-
 protocol PusherKeyProviding {
     var decryptionKey: String { get }
 }
@@ -12,4 +10,5 @@ class PusherKeyProvider: PusherKeyProviding {
     init(decryptionKey: String) {
         self.decryptionKey = decryptionKey
     }
+    
 }

--- a/Sources/PusherWebsocketDelegate.swift
+++ b/Sources/PusherWebsocketDelegate.swift
@@ -26,6 +26,11 @@ extension PusherConnection: WebSocketDelegate {
             }
             self.handleError(error: error)
         } else {
+            var keyProvider: PusherKeyProviding? = nil
+            if let channelName = payload["channel"] as? String {
+                keyProvider = self.keyProvider(forChannel: channelName)
+            }
+            
             guard let event = PusherEvent(jsonObject: payload, keyProvider: keyProvider) else {
                 self.delegate?.debugLog?(message: "[PUSHER DEBUG] Unable to handle incoming event \(text)")
                 return


### PR DESCRIPTION
### Description of the pull request

Store shared secret for private encrypted channels.

`PusherConnection` is not covered by unit tests, so I would suggest to write some end-to-end tests when the feature is ready.

#### Why is the change necessary?

Roadmap
