### PR TITLE
Make key provider thread safe

### DIFF
--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -213,9 +213,7 @@ import Starscream
             )
 
             self.channels.remove(name: channelName)
-            DispatchQueue.main.async {
-                self.keyProvider.clearDecryptionKey(forChannelName: channelName)
-            }
+            self.keyProvider.clearDecryptionKey(forChannelName: channelName)
         }
     }
     

--- a/Sources/PusherKeyProvider.swift
+++ b/Sources/PusherKeyProvider.swift
@@ -10,6 +10,8 @@ protocol PusherKeyProvider: AnyObject {
 
 class PusherConcreteKeyProvider: PusherKeyProvider {
 
+    private var queue = DispatchQueue(label: "com.pusher.pusherswift-key-provider-\(UUID().uuidString)")
+
     // MARK: - Properties
 
     private var decryptionKeys: [String : String] = [:]
@@ -17,14 +19,20 @@ class PusherConcreteKeyProvider: PusherKeyProvider {
     // MARK: - Key provider
 
     func decryptionKey(forChannelName channelName: String) -> String? {
-        return self.decryptionKeys[channelName]
+        return queue.sync {
+            return self.decryptionKeys[channelName]
+        }
     }
 
     func setDecryptionKey(_ decryptionKey: String, forChannelName channelName: String) {
-        self.decryptionKeys[channelName] = decryptionKey
+        queue.sync {
+            self.decryptionKeys[channelName] = decryptionKey
+        }
     }
 
     func clearDecryptionKey(forChannelName channelName: String) {
-        self.decryptionKeys.removeValue(forKey: channelName)
+        queue.sync {
+            _ = self.decryptionKeys.removeValue(forKey: channelName)
+        }
     }
 }


### PR DESCRIPTION
The key provider will be accessed from multiple threads: keys are cleared when the user calls "unsubscribe" on whichever thread they are using, set by the response of a URLSession dataTask and read in the EventQueue dispatch queue thread. This PR ensures there aren't concurrent accesses to the `decryptionKeys` Dictionary from those different threads.
