### PR TITLE
Invalid encrypted payload should mean a call to failedToDecrypt

### DIFF
--- a/Sources/PusherEventFactory.swift
+++ b/Sources/PusherEventFactory.swift
@@ -60,5 +60,6 @@ enum PusherEventError: Error {
     
     case invalidFormat
     case invalidDecryptionKey
+    case invalidEncryptedData
     
 }

--- a/Sources/PusherEventQueue.swift
+++ b/Sources/PusherEventQueue.swift
@@ -44,6 +44,10 @@ class PusherConcreteEventQueue: PusherEventQueue {
                         self.delegate?.eventQueue(self, didFailToDecryptEventWithPayload: json, forChannelName: channelName)
                     }
                 }
+            } catch PusherEventError.invalidEncryptedData {
+                if let channelName = channelName {
+                    self.delegate?.eventQueue(self, didFailToDecryptEventWithPayload: json, forChannelName: channelName)
+                }
             } catch {
                 self.delegate?.eventQueue(self, didReceiveInvalidEventWithPayload: json)
             }

--- a/Sources/PusherSwiftWithEncryption-Only/PusherDecryptor.swift
+++ b/Sources/PusherSwiftWithEncryption-Only/PusherDecryptor.swift
@@ -35,7 +35,7 @@ class PusherDecryptor {
     private static func encryptedData(fromData data: String) throws -> EncryptedData {
         guard let encodedData = data.data(using: .utf8),
             let encryptedData = try? JSONDecoder().decode(EncryptedData.self, from: encodedData) else {
-                throw PusherEventError.invalidFormat
+                throw PusherEventError.invalidEncryptedData
         }
 
         return encryptedData
@@ -43,7 +43,7 @@ class PusherDecryptor {
 
     private static func decodedCipherText(fromEncryptedData encryptedData: EncryptedData) throws -> Bytes {
         guard let decodedCipherText = Data(base64Encoded: encryptedData.ciphertext) else {
-            throw PusherEventError.invalidFormat
+            throw PusherEventError.invalidEncryptedData
         }
 
         return Bytes(decodedCipherText)
@@ -51,7 +51,7 @@ class PusherDecryptor {
 
     private static func decodedNonce(fromEncryptedData encryptedData: EncryptedData) throws -> SecretBox.Nonce {
         guard let decodedNonce = Data(base64Encoded: encryptedData.nonce) else {
-            throw PusherEventError.invalidFormat
+            throw PusherEventError.invalidEncryptedData
         }
 
         return SecretBox.Nonce(decodedNonce)

--- a/Tests/PusherSwiftWithEncryption-Only/PusherEventFactory+DecryptionTests.swift
+++ b/Tests/PusherSwiftWithEncryption-Only/PusherEventFactory+DecryptionTests.swift
@@ -140,7 +140,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
         }
     }
 
-    func test_init_encryptedChannelAndUserEventAndUnencryptedPayloadWithDecryptionKey_throwsInvalidFormat() {
+    func test_init_encryptedChannelAndUserEventAndUnencryptedPayloadWithDecryptionKey_throwsInvalidEncryptedData() {
         let decryptionKey = "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs="
 
         let dataPayload = """
@@ -159,7 +159,51 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
         """.toJsonDict()
 
         XCTAssertThrowsError(try eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: decryptionKey)) { (error) in
-            XCTAssertEqual(error as? PusherEventError, PusherEventError.invalidFormat)
+            XCTAssertEqual(error as? PusherEventError, PusherEventError.invalidEncryptedData)
+        }
+    }
+
+    func test_init_encryptedChannelAndUserEventAndEncryptedPayloadMissingNonce_throwsInvalidEncryptedData() {
+        let decryptionKey = "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs="
+
+        let dataPayload = """
+        {
+            "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
+        }
+        """.removing(.whitespacesAndNewlines)
+
+        let jsonDict = """
+        {
+            "event": "user-event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+
+        XCTAssertThrowsError(try eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: decryptionKey)) { (error) in
+            XCTAssertEqual(error as? PusherEventError, PusherEventError.invalidEncryptedData)
+        }
+    }
+
+    func test_init_encryptedChannelAndUserEventAndEncryptedPayloadMissingCiphertext_throwsInvalidEncryptedData() {
+        let decryptionKey = "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs="
+
+        let dataPayload = """
+        {
+            "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm"
+        }
+        """.removing(.whitespacesAndNewlines)
+
+        let jsonDict = """
+        {
+            "event": "user-event",
+            "channel": "private-encrypted-channel",
+            "data": \(dataPayload.escaped)
+        }
+        """.toJsonDict()
+
+        XCTAssertThrowsError(try eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: decryptionKey)) { (error) in
+            XCTAssertEqual(error as? PusherEventError, PusherEventError.invalidEncryptedData)
         }
     }
     


### PR DESCRIPTION
There is a difference between a bad pusher event (e.g. missing the `event` key) and a valid pusher event, but with an invalid encrypted payload (missing nonce, ciphertext or both). We want to handle these differently. A bad payload should result in a call to the `failedToDecryptEvent` callback.