### PR TITLE
Add warning message for wrong PusherSwift version

### DIFF
--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		E2594CE224475E6000E36300 /* PusherKeyProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2594CE024475E6000E36300 /* PusherKeyProviderTests.swift */; };
 		E2594CE42447753200E36300 /* PusherEventQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2594CE32447753200E36300 /* PusherEventQueueTests.swift */; };
 		E2594CE52447753200E36300 /* PusherEventQueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2594CE32447753200E36300 /* PusherEventQueueTests.swift */; };
+		E26B8606244A079E00735172 /* PusherEncryptionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B8605244A079E00735172 /* PusherEncryptionHelpers.swift */; };
+		E26B8607244A079E00735172 /* PusherEncryptionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26B8605244A079E00735172 /* PusherEncryptionHelpers.swift */; };
 		E291AFA024486A6E00594552 /* PusherEventQueue+DecryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291AF9E2448636400594552 /* PusherEventQueue+DecryptionTests.swift */; };
 		E291AFA324486CAE00594552 /* PusherEventQueue+DecryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E291AFA124486CAB00594552 /* PusherEventQueue+DecryptionTests.swift */; };
 		E29A4CBC2301BA31000BC499 /* PusherEventFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E29A4CBB2301BA31000BC499 /* PusherEventFactoryTests.swift */; };
@@ -149,6 +151,7 @@
 		E2498292231E612700CFBBD6 /* PusherError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherError.swift; sourceTree = "<group>"; };
 		E2594CE024475E6000E36300 /* PusherKeyProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherKeyProviderTests.swift; sourceTree = "<group>"; };
 		E2594CE32447753200E36300 /* PusherEventQueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEventQueueTests.swift; sourceTree = "<group>"; };
+		E26B8605244A079E00735172 /* PusherEncryptionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEncryptionHelpers.swift; sourceTree = "<group>"; };
 		E291AF9E2448636400594552 /* PusherEventQueue+DecryptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PusherEventQueue+DecryptionTests.swift"; sourceTree = "<group>"; };
 		E291AFA124486CAB00594552 /* PusherEventQueue+DecryptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PusherEventQueue+DecryptionTests.swift"; sourceTree = "<group>"; };
 		E29A4CBB2301BA31000BC499 /* PusherEventFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherEventFactoryTests.swift; sourceTree = "<group>"; };
@@ -241,6 +244,7 @@
 				E2F40FA423ED782B00985C40 /* PusherCrypto.swift */,
 				E2B21EFE243F5B1E0049A35B /* PusherEventFactory.swift */,
 				E2B21EFD243F5B1E0049A35B /* PusherEventQueue.swift */,
+				E26B8605244A079E00735172 /* PusherEncryptionHelpers.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -542,6 +546,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E26B8606244A079E00735172 /* PusherEncryptionHelpers.swift in Sources */,
 				E2B21F0A243F5BB50049A35B /* PusherConnection.swift in Sources */,
 				33BA54201D9035BD00CD853B /* PusherDelegate.swift in Sources */,
 				E2498293231E612700CFBBD6 /* PusherError.swift in Sources */,
@@ -595,6 +600,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E26B8607244A079E00735172 /* PusherEncryptionHelpers.swift in Sources */,
 				E2B21F0B243F5BB50049A35B /* PusherConnection.swift in Sources */,
 				73D8A1E72435E5F3001FDE05 /* PusherDelegate.swift in Sources */,
 				73D8A1E82435E5F3001FDE05 /* PusherError.swift in Sources */,

--- a/Sources/PusherEncryptionHelpers.swift
+++ b/Sources/PusherEncryptionHelpers.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct PusherEncryptionHelpers {
+
+    public static func shouldDecryptMessage(eventName: String, channelName: String?) -> Bool {
+        return isEncryptedChannel(channelName: channelName) && !isPusherSystemEvent(eventName: eventName)
+    }
+
+    public static func isEncryptedChannel(channelName: String?) -> Bool {
+        return channelName?.starts(with: "private-encrypted-") ?? false
+    }
+
+    public static func isPusherSystemEvent(eventName: String) -> Bool {
+        return eventName.starts(with: "pusher:") || eventName.starts(with: "pusher_internal:")
+    }
+}

--- a/Sources/PusherEventFactory.swift
+++ b/Sources/PusherEventFactory.swift
@@ -29,24 +29,13 @@ struct PusherConcreteEventFactory: PusherEventFactory {
     private func data(fromJSON json: PusherEventPayload, eventName: String, channelName: String?, decryptionKey: String?) throws -> String? {
         let data = json["data"] as? String
         
-        if self.isEncryptedChannel(channelName: channelName) && !self.isPusherSystemEvent(eventName: eventName) {
+        if PusherEncryptionHelpers.shouldDecryptMessage(eventName: eventName, channelName: channelName) {
             return try PusherDecryptor.decrypt(data: data, decryptionKey: decryptionKey)
         }
         else {
             return data
         }
     }
-    
-    private func isEncryptedChannel(channelName: String?) -> Bool {
-        return channelName?.starts(with: "private-encrypted-") ?? false
-    }
-    
-    private func isPusherSystemEvent(eventName: String) -> Bool {
-        return eventName.starts(with: "pusher:") || eventName.starts(with: "pusher_internal:")
-    }
-    
-   
-    
 }
 
 

--- a/Sources/PusherSwift-Only/PusherDecryptor.swift
+++ b/Sources/PusherSwift-Only/PusherDecryptor.swift
@@ -4,5 +4,18 @@ class PusherDecryptor {
     static func decrypt(data dataAsString: String?, decryptionKey: String?) throws -> String? {
         return dataAsString
     }
+
+    static func encryptedChannelWarning(forChannelName channelName: String) {
+        if PusherEncryptionHelpers.isEncryptedChannel(channelName: channelName) {
+            let error = """
+
+            WARNING: You are subscribing to an encrypted channel: '\(channelName)' but this version of PusherSwift does not \
+            support end-to-end encryption. Events will not be decrypted. You must import 'PusherSwiftWithEncryption' in \
+            order for events to be decrypted. See https://github.com/pusher/pusher-websocket-swift for more information
+
+            """
+            print(error)
+        }
+    }
     
 }

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -50,6 +50,20 @@ let CLIENT_NAME = "pusher-websocket-swift"
         onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
     ) -> PusherChannel {
+
+        #if !WITH_ENCRYPTION
+        if PusherEncryptionHelpers.isEncryptedChannel(channelName: channelName) {
+            let error = """
+
+            WARNING: You are subscribing to an encrypted channel: '\(channelName)' but this version of PusherSwift does not \
+            support end-to-end encryption. Events will not be decrypted. You must import 'PusherSwiftWithEncryption' in \
+            order for events to be decrypted. See https://github.com/pusher/pusher-websocket-swift for more information
+
+            """
+            print(error)
+        }
+        #endif
+
         return self.connection.subscribe(
             channelName: channelName,
             auth: auth,

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -51,18 +51,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
         onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
     ) -> PusherChannel {
 
-        #if !WITH_ENCRYPTION
-        if PusherEncryptionHelpers.isEncryptedChannel(channelName: channelName) {
-            let error = """
-
-            WARNING: You are subscribing to an encrypted channel: '\(channelName)' but this version of PusherSwift does not \
-            support end-to-end encryption. Events will not be decrypted. You must import 'PusherSwiftWithEncryption' in \
-            order for events to be decrypted. See https://github.com/pusher/pusher-websocket-swift for more information
-
-            """
-            print(error)
-        }
-        #endif
+        PusherDecryptor.encryptedChannelWarning(forChannelName: channelName)
 
         return self.connection.subscribe(
             channelName: channelName,

--- a/Sources/PusherSwiftWithEncryption-Only/PusherDecryptor.swift
+++ b/Sources/PusherSwiftWithEncryption-Only/PusherDecryptor.swift
@@ -65,5 +65,9 @@ class PusherDecryptor {
         return SecretBox.Key(decodedDecryptionKey)
     }
 
+    static func encryptedChannelWarning(forChannelName channelName: String) {
+        // No warning necessary because encrypted channels are supported in this version
+    }
+
     
 }


### PR DESCRIPTION
Add a warning message that displays if someone tries to subscribe to an encrypted channel in the PusherSwift rather than PusherSwiftWithEncryption
