### PR TITLE
Change to encrypted option to useTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ let package = Package(
 There are a number of configuration parameters which can be set for the Pusher client. For Swift usage they are:
 
 - `authMethod (AuthMethod)` - the method you would like the client to use to authenticate subscription requests to channels requiring authentication (see below for more details)
-- `encrypted (Bool)` - whether or not you'd like to use encypted transport or not, default is `true`
+- `useTLS (Bool)` - whether or not you'd like to use TLS encrypted transport or not, default is `true`
 - `autoReconnect (Bool)` - set whether or not you'd like the library to try and autoReconnect upon disconnection
 - `host (PusherHost)` - set a custom value for the host you'd like to connect to, e.g. `PusherHost.host("ws-test.pusher.com")`
 - `port (Int)` - set a custom value for the port that you'd like to connect to
@@ -232,7 +232,7 @@ PusherClientOptions *options = [[PusherClientOptions alloc]
                                 autoReconnect:YES
                                 ocHost:host
                                 port:nil
-                                encrypted:YES
+                                useTLS:YES
                                 activityTimeout:nil];
 ```
 
@@ -258,7 +258,7 @@ PusherClientOptions *options = [[PusherClientOptions alloc]
                                 autoReconnect:YES
                                 ocHost:host
                                 port:nil
-                                encrypted:YES
+                                useTLS:YES
                                 activityTimeout:nil];
 pusher = [[Pusher alloc] initWithAppKey:@"YOUR_APP_KEY" options:options];
 ```

--- a/Sources/ObjectiveC.swift
+++ b/Sources/ObjectiveC.swift
@@ -62,7 +62,7 @@ import Foundation
         autoReconnect: Bool = true,
         ocHost host: OCPusherHost = PusherHost.host("ws.pusherapp.com").toObjc(),
         port: NSNumber? = nil,
-        encrypted: Bool = true,
+        useTLS: Bool = true,
         activityTimeout: NSNumber? = nil
     ) {
         self.init(
@@ -71,7 +71,7 @@ import Foundation
             autoReconnect: autoReconnect,
             ocHost: host,
             port: port,
-            encrypted: encrypted,
+            useTLS: useTLS,
             activityTimeout: activityTimeout
         )
     }
@@ -82,7 +82,7 @@ import Foundation
         autoReconnect: Bool = true,
         ocHost host: OCPusherHost = PusherHost.host("ws.pusherapp.com").toObjc(),
         port: NSNumber? = nil,
-        encrypted: Bool = true,
+        useTLS: Bool = true,
         activityTimeout: NSNumber? = nil
     ) {
         self.init(
@@ -91,7 +91,7 @@ import Foundation
             autoReconnect: autoReconnect,
             host: PusherHost.fromObjc(source: host),
             port: port as? Int,
-            encrypted: encrypted,
+            useTLS: useTLS,
             activityTimeout: activityTimeout as? TimeInterval
         )
     }

--- a/Sources/PusherClientOptions.swift
+++ b/Sources/PusherClientOptions.swift
@@ -27,7 +27,7 @@ public enum AuthMethod {
     public let autoReconnect: Bool
     public let host: String
     public let port: Int
-    public let encrypted: Bool
+    public let useTLS: Bool
     public let activityTimeout: TimeInterval?
 
     @nonobjc public init(
@@ -36,15 +36,15 @@ public enum AuthMethod {
         autoReconnect: Bool = true,
         host: PusherHost = .host("ws.pusherapp.com"),
         port: Int? = nil,
-        encrypted: Bool = true,
+        useTLS: Bool = true,
         activityTimeout: TimeInterval? = nil
     ) {
         self.authMethod = authMethod
         self.attemptToReturnJSONObject = attemptToReturnJSONObject
         self.autoReconnect = autoReconnect
         self.host = host.stringValue
-        self.port = port ?? (encrypted ? 443 : 80)
-        self.encrypted = encrypted
+        self.port = port ?? (useTLS ? 443 : 80)
+        self.useTLS = useTLS
         self.activityTimeout = activityTimeout
     }
 }

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -174,7 +174,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
 func constructUrl(key: String, options: PusherClientOptions) -> String {
     var url = ""
 
-    if options.encrypted {
+    if options.useTLS {
         url = "wss://\(options.host):\(options.port)/app/\(key)"
     } else {
         url = "ws://\(options.host):\(options.port)/app/\(key)"

--- a/Tests/PusherClientInitializationTests.swift
+++ b/Tests/PusherClientInitializationTests.swift
@@ -49,7 +49,7 @@ class ClientInitializationTests: XCTestCase {
 
     func testProvidingEcryptedOptionAsFalse() {
         let options = PusherClientOptions(
-            encrypted: false
+            useTLS: false
         )
         pusher = Pusher(key: key, options: options)
         XCTAssertEqual(pusher.connection.url, "ws://ws.pusherapp.com:80/app/testKey123?client=pusher-websocket-swift&version=\(VERSION)&protocol=7", "the connection should be set correctly")


### PR DESCRIPTION
Now that the library has end-to-end encryption support, the meaning of the `encrypted` configuration option is less clear. This PR updates the library to be consistent with other libraries with a `useTLS` option. 

pusher-js has a`forceTLS` option rather than `useTLS`. However the behaviour of that library is different. By default it tries a number of strategies in sequence, including ws and wss. The flag forces the library to only use the  TLS encrypted options e.g. wss. In this library, whether or not the connection uses TLS is entirely determined by whether `encrypted`/`useTLS` is set (same as the server SDKs), so `useTLS` seems more appropriate.