### PR TITLE
Subscription event is not triggered if data is null.

### DIFF
--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -481,12 +481,7 @@ import Starscream
         if let channelName = event.channelName, let chan = self.channels.find(name: channelName) {
             chan.subscribed = true
 
-            guard event.data != nil else {
-                self.delegate?.debugLog?(message: "[PUSHER DEBUG] Subscription succeeded event received without data key in payload")
-                return
-            }
-
-            if PusherChannelType.isPresenceChannel(name: channelName) {
+            if event.data != nil && PusherChannelType.isPresenceChannel(name: channelName) {
                 if let presChan = self.channels.find(name: channelName) as? PusherPresenceChannel {
                     if let dataJSON = event.dataToJSONObject() as? [String: Any], let presenceData = dataJSON["presence"] as? [String: AnyObject],
                        let presenceHash = presenceData["hash"] as? [String: AnyObject]


### PR DESCRIPTION
When Subscription Succeeded event was received with no data, the event listeners were not triggered.

Subscription succeeded message was an essential event to listen to.