### PR TITLE
Update to Starscream 4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ashleymills/Reachability.swift.git", .upToNextMajor(from: "5.0.0")),
-        .package(url: "https://github.com/daltoniam/Starscream.git", .upToNextMajor(from: "3.1.0")),
+        .package(url: "https://github.com/JonathanDowning/Starscream.git", .branch("feature/WebSocketDelegate-change")),
     ],
     targets: [
         .target(

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -11,7 +11,7 @@ import Starscream
     open var socketId: String?
     open var connectionState = ConnectionState.disconnected
     open var channels = PusherChannels()
-    open var socket: WebSocket!
+    open var socket: WebSocketClient!
     open var URLSession: Foundation.URLSession
     open var userDataFetcher: (() -> PusherPresenceChannelMember)?
     open var reconnectAttemptsMax: Int? = nil
@@ -97,7 +97,7 @@ import Starscream
     */
     public init(
         key: String,
-        socket: WebSocket,
+        socket: WebSocketClient,
         url: String,
         options: PusherClientOptions,
         URLSession: Foundation.URLSession = Foundation.URLSession.shared
@@ -115,8 +115,6 @@ import Starscream
         super.init()
 
         self.eventQueue.delegate = self
-        self.socket.delegate = self
-        self.socket.pongDelegate = self
     }
 
     deinit {

--- a/Sources/PusherCrypto.swift
+++ b/Sources/PusherCrypto.swift
@@ -17,9 +17,9 @@ struct PusherCrypto {
 
         var digest = Data(count: digestLength)
 
-        _ = digest.withUnsafeMutableBytes { (digestBytes: UnsafeMutableRawBufferPointer) in
-            _ = secretData.withUnsafeBytes { (secretBytes: UnsafeRawBufferPointer) in
-                _ = messageData.withUnsafeBytes { (messageBytes: UnsafeRawBufferPointer) in
+        digest.withUnsafeMutableBytes { (digestBytes: UnsafeMutableRawBufferPointer) in
+            secretData.withUnsafeBytes { (secretBytes: UnsafeRawBufferPointer) in
+                messageData.withUnsafeBytes { (messageBytes: UnsafeRawBufferPointer) in
                     CCHmac(algorithm, secretBytes.baseAddress, secretData.count, messageBytes.baseAddress, messageData.count, digestBytes.baseAddress)
                 }
             }

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -26,8 +26,9 @@ let CLIENT_NAME = "pusher-websocket-swift"
     public init(key: String, options: PusherClientOptions = PusherClientOptions()) {
         self.key = key
         let urlString = constructUrl(key: key, options: options)
-        let ws = WebSocket(url: URL(string: urlString)!)
+        let ws = WebSocket(request: URLRequest(url: URL(string: urlString)!), useCustomEngine: false)
         connection = PusherConnection(key: key, socket: ws, url: urlString, options: options)
+        ws.delegate = connection
         connection.createGlobalChannel()
     }
 

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -7,16 +7,17 @@ import Starscream
     @testable import PusherSwift
 #endif
 
-open class MockWebSocket: WebSocket {
+open class MockWebSocket: WebSocketClient {
+
     let stubber = StubberForMocks()
     var callbackCheckString: String = ""
     var objectGivenToCallback: Any? = nil
     var eventGivenToCallback: PusherEvent? = nil
+    open weak var delegate: WebSocketDelegate?
 
     init() {
         var request = URLRequest(url: URL(string: "test")!)
         request.timeoutInterval = 5
-        super.init(request: request, protocols: [])
     }
 
     open func appendToCallbackCheckString(_ str: String) {
@@ -31,15 +32,15 @@ open class MockWebSocket: WebSocket {
         self.eventGivenToCallback = event
     }
 
-    open override func connect() {
+    open func connect() {
         let connectionEstablishedString = "{\"event\":\"pusher:connection_established\",\"data\":\"{\\\"socket_id\\\":\\\"45481.3166671\\\",\\\"activity_timeout\\\":120}\"}"
         let _ = stubber.stub(
             functionName: "connect",
             args: nil,
             functionToCall: {
                 if let delegate = self.delegate {
-                    delegate.websocketDidReceiveMessage(socket: self, text: connectionEstablishedString)
-                    delegate.websocketDidConnect(socket: self)
+                    delegate.didReceive(event: .text(connectionEstablishedString), client: self)
+                    delegate.didReceive(event: .connected([:]), client: self)
                 } else {
                     print("Your socket delegate is nil")
                 }
@@ -47,23 +48,31 @@ open class MockWebSocket: WebSocket {
         )
     }
 
-    open override func disconnect(forceTimeout: TimeInterval? = nil, closeCode: UInt16 = CloseCode.normal.rawValue) {
+    open func disconnect(closeCode: UInt16) {
         let _ = stubber.stub(
             functionName: "disconnect",
             args: nil,
             functionToCall: {
-                self.delegate?.websocketDidDisconnect(socket: self, error: nil)
+                self.delegate?.didReceive(event: .disconnected("", CloseCode.normal.rawValue), client: self)
             }
         )
     }
 
-    open override func write(string: String, completion: (() -> ())? = nil) {
+    open func write(data: Data, completion: (() -> ())?) {}
+
+    open func write(ping: Data, completion: (() -> ())?) {}
+
+    open func write(pong: Data, completion: (() -> ())?) {}
+
+    open func write(stringData: Data, completion: (() -> ())?) {}
+
+    open func write(string: String, completion: (() -> ())?) {
         if string == "{\"data\":{\"channel\":\"test-channel\"},\"event\":\"pusher:subscribe\"}" || string == "{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"test-channel\"}}" {
             let _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"test-channel\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"test-channel\",\"data\":\"{}\"}"), client: self)
                 }
             )
         } else if string == "{\"data\":{\"channel\":\"test-channel2\"},\"event\":\"pusher:subscribe\"}" || string == "{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"test-channel2\"}}" {
@@ -71,7 +80,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"test-channel2\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"test-channel2\",\"data\":\"{}\"}"), client: self)
             }
             )
         } else if stringContainsElements(string, elements: ["testkey123:6aae8814fabd5285245422096705abbed64ea59614648814ffb0bf2dc5d19168", "private-channel", "pusher:subscribe"]) {
@@ -79,7 +88,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-channel\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-channel\",\"data\":\"{}\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["key:5ce61ee2b8594e22b66323913d7c7af9d8e815659365be3627733993f4ce3824", "presence-channel", "user_id", "45481.3166671", "pusher:subscribe"]) {
@@ -87,7 +96,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"46123.486095\\\"],\\\"hash\\\":{\\\"46123.486095\\\":null}}}\",\"channel\":\"presence-channel\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"46123.486095\\\"],\\\"hash\\\":{\\\"46123.486095\\\":null}}}\",\"channel\":\"presence-channel\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["testkey123:5ce61ee2b8594e22b66323913d7c7af9d8e815659365be3627733993f4ce3824", "presence-channel", "user_id", "45481.3166671", "pusher:subscribe"]) {
@@ -95,7 +104,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"46123.486095\\\"],\\\"hash\\\":{\\\"46123.486095\\\":null}}}\",\"channel\":\"presence-channel\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"46123.486095\\\"],\\\"hash\\\":{\\\"46123.486095\\\":null}}}\",\"channel\":\"presence-channel\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["key:e1d0947a10d6ff1a25990798910b2505687bb096e3e8b6c97eef02c6b1abb4c7", "private-channel", "pusher:subscribe"]) {
@@ -103,7 +112,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-channel\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-channel\",\"data\":\"{}\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["data", "testing client events", "private-channel", "client-test-event"]) {
@@ -117,7 +126,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-test-channel\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-test-channel\",\"data\":\"{}\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:12345678gfder78ikjbgmanualauth", "private-manual-auth"]) {
@@ -125,7 +134,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-manual-auth\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-manual-auth\",\"data\":\"{}\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:12345678gfder78ikjbgmanualauth", "presence-manual-auth"]) {
@@ -133,7 +142,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"presence-manual-auth\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"16\\\"],\\\"hash\\\":{\\\"16\\\":{\\\"twitter\\\":\\\"hamchapman\\\"}}}}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"presence-manual-auth\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"16\\\"],\\\"hash\\\":{\\\"16\\\":{\\\"twitter\\\":\\\"hamchapman\\\"}}}}\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["key:0d0d2e7c2cd967246d808180ef0f115dad51979e48cac9ad203928141f9e6a6f", "private-test-channel", "pusher:subscribe"]) {
@@ -141,7 +150,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-test-channel\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-test-channel\",\"data\":\"{}\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["private-reservations-for-venue@venue_id=399edd2d-3f4a-43k9-911c-9e4b6bdf0f16;date=2017-01-13", "pusher:subscribe", "testKey123:12345678gfder78ikjbg"]) {
@@ -149,7 +158,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-reservations-for-venue@venue_id=399edd2d-3f4a-43k9-911c-9e4b6bdf0f16;date=2017-01-13\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-reservations-for-venue@venue_id=399edd2d-3f4a-43k9-911c-9e4b6bdf0f16;date=2017-01-13\",\"data\":\"{}\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["test-channel", "pusher:unsubscribe"]) {
@@ -170,7 +179,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"123\\\"],\\\"hash\\\":{\\\"123\\\":{\\\"twitter\\\":\\\"hamchapman\\\"}}}}\",\"channel\":\"presence-test\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"123\\\"],\\\"hash\\\":{\\\"123\\\":{\\\"twitter\\\":\\\"hamchapman\\\"}}}}\",\"channel\":\"presence-test\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["key:c2b53f001321bc088814f210fb63c259b464f590890eee2dde6387ea9b469a30", "presence-channel", "user_id", "123", "pusher:subscribe"]) {
@@ -178,7 +187,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"123\\\"],\\\"hash\\\":{\\\"123\\\":{}}}}\",\"channel\":\"presence-channel\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"123\\\"],\\\"hash\\\":{\\\"123\\\":{}}}}\",\"channel\":\"presence-channel\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "presence-channel", "friends", "0", "user_id", "123"]) && (stringContainsElements(string, elements: ["key:dd2885ee6dc6f5c964d8e3c720980397db50bf8f528e0630d4208bff80ee23f0"]) || stringContainsElements(string, elements: ["key:80cfefb0ef08fb55353dbbc0480e6160059fac14fce862e9ed1f0121ae8a440f"])) {
@@ -187,7 +196,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"123\\\"],\\\"hash\\\":{\\\"123\\\":{\\\"friends\\\":0}}}}\",\"channel\":\"presence-channel\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"123\\\"],\\\"hash\\\":{\\\"123\\\":{\\\"friends\\\":0}}}}\",\"channel\":\"presence-channel\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:authorizerblah123", "private-test-channel-authorizer"]) {
@@ -195,7 +204,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-test-channel-authorizer\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-test-channel-authorizer\",\"data\":\"{}\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:authorizerblah1234", "presence-test-channel-authorizer"]) {
@@ -203,7 +212,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"777\\\"],\\\"hash\\\":{\\\"777\\\":{\\\"twitter\\\":\\\"hamchapman\\\"}}}}\",\"channel\":\"presence-test-channel-authorizer\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"777\\\"],\\\"hash\\\":{\\\"777\\\":{\\\"twitter\\\":\\\"hamchapman\\\"}}}}\",\"channel\":\"presence-test-channel-authorizer\"}"), client: self)
                 }
             )
         } else if stringContainsElements(string, elements: ["private-encrypted-channel", "pusher:subscribe", "636a81ba7e7b15725c00:3ee04892514e8a669dc5d30267221f16727596688894712cad305986e6fc0f3c"]) {
@@ -211,7 +220,7 @@ open class MockWebSocket: WebSocket {
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
-                    self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-encrypted-channel\",\"data\":\"{}\"}")
+                    self.delegate?.didReceive(event: .text("{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-encrypted-channel\",\"data\":\"{}\"}"), client: self)
             } )
         } else {
             print("No match in write(string: ...) mock for string: \(string)")

--- a/Tests/PresenceChannelTests.swift
+++ b/Tests/PresenceChannelTests.swift
@@ -107,7 +107,7 @@ class PusherPresenceChannelTests: XCTestCase {
                 "data": "{\\"user_id\\":\\"100\\", \\"user_info\\":{\\"twitter\\":\\"hamchapman\\"}}"
             }
             """.removing(.newlines)
-            self.pusher.connection.websocketDidReceiveMessage(socket: self.socket, text: jsonDict)
+            self.pusher.connection.didReceive(event: .text(jsonDict), client: self.socket)
         }
 
         waitForExpectations(timeout: 0.5)
@@ -188,7 +188,7 @@ class PusherPresenceChannelTests: XCTestCase {
                 "data": "{\\"user_id\\":\\"100\\"}"
             }
             """.removing(.newlines)
-            self.pusher.connection.websocketDidReceiveMessage(socket: self.socket, text: jsonDict)
+            self.pusher.connection.didReceive(event: .text(jsonDict), client: self.socket)
         }
         waitForExpectations(timeout: 0.5)
     }
@@ -212,7 +212,7 @@ class PusherPresenceChannelTests: XCTestCase {
                 "data": "{\\"user_id\\":\\"100\\"}"
             }
             """.removing(.newlines)
-            self.pusher.connection.websocketDidReceiveMessage(socket: self.socket, text: jsonDict)
+            self.pusher.connection.didReceive(event: .text(jsonDict), client: self.socket)
         }
         waitForExpectations(timeout: 0.5)
     }
@@ -235,7 +235,7 @@ class PusherPresenceChannelTests: XCTestCase {
                 "data": "{\\"user_id\\":100}"
             }
             """.removing(.newlines)
-            self.pusher.connection.websocketDidReceiveMessage(socket: self.socket, text: addedJsonDict)
+            self.pusher.connection.didReceive(event: .text(addedJsonDict), client: self.socket)
 
             let removedJsonDict = """
             {
@@ -244,7 +244,7 @@ class PusherPresenceChannelTests: XCTestCase {
                 "data": "{\\"user_id\\":100}"
             }
             """.removing(.newlines)
-            self.pusher.connection.websocketDidReceiveMessage(socket: self.socket, text: removedJsonDict)
+            self.pusher.connection.didReceive(event: .text(removedJsonDict), client: self.socket)
         }
         waitForExpectations(timeout: 0.5)
     }

--- a/Tests/PusherConnectionDelegateTests.swift
+++ b/Tests/PusherConnectionDelegateTests.swift
@@ -139,7 +139,7 @@ class PusherConnectionDelegateTests: XCTestCase {
 
     func testErrorFunctionCalledWhenPusherErrorIsReceived() {
         let payload = "{\"event\":\"pusher:error\", \"data\":{\"message\":\"Application is over connection quota\",\"code\":4004}}";
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: payload)
+        pusher.connection.didReceive(event: .text(payload), client: socket)
 
         XCTAssertEqual(dummyDelegate.stubber.calls.last?.name, "error")
         guard let error = dummyDelegate.stubber.calls.last?.args?.first as? PusherError else {

--- a/Tests/PusherIncomingEventHandlingTests.swift
+++ b/Tests/PusherIncomingEventHandlingTests.swift
@@ -35,7 +35,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "stupid data"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -54,7 +54,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "stupid data"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -76,7 +76,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "stupid data"
         }
         """.removing(.whitespacesAndNewlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -97,7 +97,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -123,7 +123,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -156,7 +156,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": {"code": "<null>", "message": "Existing subscription to channel my-channel"}
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -179,7 +179,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -202,7 +202,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "test"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -228,7 +228,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -247,7 +247,7 @@ class HandlingIncomingEventsTests: XCTestCase {
         // pretend that we tried to subscribe to my-channel twice and got this error
         // back from Pusher
         let payload = "{\"event\":\"pusher:error\", \"data\":{\"message\":\"Existing subscription to channel my-channel\"}}";
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: payload)
+        pusher.connection.didReceive(event: .text(payload), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -280,7 +280,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -314,7 +314,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
         """.removing(.newlines)
-        pusher.connection.websocketDidReceiveMessage(socket: socket, text: jsonDict)
+        pusher.connection.didReceive(event: .text(jsonDict), client: socket)
 
         waitForExpectations(timeout: 0.5)
     }


### PR DESCRIPTION
### Description of the pull request

This PR updates Starscream to version 4.

#### Why is the change necessary?

An app I work on is experiencing a fairly high number of `Attempted to dereference garbage pointer` crashes and I would like to narrow down where these are coming from.
My motivation for updating Starscream to version 4 is to use Foundation's built in `URLSessionWebSocketTask`, which Starscream 4 supports, in the hope this reduces crashes like this versions of our app running iOS 13+.

Caveats of this implementation are that it uses my fork of starscream to get around the `WebSocket`/`WebSocketClient` method issue which was [brought up](https://github.com/daltoniam/Starscream/issues/811) by yourselves, I'd not be surprised if you wished to wait until this is merged into the main branch of Starscream before merging this in.

I've also done the bare minimum to get this up and running and wouldn't be surprised or offended if you had issues with the cleanliness of the code here.

You may end up wishing to do this migration yourselves but I thought id open this PR anyway to at least get a conversation going.

Thanks!