### PR TITLE
Add Swiftint support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ fastlane/screenshots
 .swift-version
 test_push.rb
 SwiftLibExampleCertificate.pem
+
+# macOS
+
+.DS_Store

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,2 @@
+excluded:
+  - Carthage

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,3 +8,7 @@ identifier_name:
   - ex
   - to
   - ws
+
+# This generates a compiler error if more than this many SwiftLint warnings are present
+# (This threshold can become more restrictive as remaining warnings are resolved via refactoring)
+warning_threshold: 25

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,10 @@
 excluded:
   - Carthage
   - Package.swift
+
+identifier_name:
+  excluded:
+  - id
+  - ex
+  - to
+  - ws

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,3 @@
 excluded:
   - Carthage
+  - Package.swift

--- a/Consumption-Tests/.swiftlint.yml
+++ b/Consumption-Tests/.swiftlint.yml
@@ -1,0 +1,2 @@
+disabled_rules:
+  - line_length

--- a/Consumption-Tests/Shared/Swift/ViewController+Extensions.swift
+++ b/Consumption-Tests/Shared/Swift/ViewController+Extensions.swift
@@ -21,7 +21,7 @@ struct DebugConsoleMessage: Codable {
 }
 
 extension ViewController {
-    
+
     func makeAndLaunchPusher() -> Pusher {
 
         // Only use your secret here for testing or if you're sure that there's  security risk
@@ -38,7 +38,7 @@ extension ViewController {
         pusher.connect()
 
         // bind to all events globally
-        let _ = pusher.bind(eventCallback: { (event: PusherEvent) in
+        _ = pusher.bind(eventCallback: { (event: PusherEvent) in
             var message = "Received event: '\(event.eventName)'"
 
             if let channel = event.channelName {
@@ -58,7 +58,7 @@ extension ViewController {
         let myChannel = pusher.subscribe("my-channel")
 
         // bind a callback to event "my-event" on that channel
-        let _ = myChannel.bind(eventName: "my-event", eventCallback: { (event: PusherEvent) in
+        _ = myChannel.bind(eventName: "my-event", eventCallback: { (event: PusherEvent) in
 
             // convert the data string to type data for decoding
             guard let json: String = event.data,
@@ -88,13 +88,13 @@ extension ViewController {
 
         // triggers a client event on that channel
         chan.trigger(eventName: "client-test", data: ["test": "some value"])
-        
+
         return pusher
     }
 }
 
 extension ViewController: PusherDelegate {
-    
+
     // PusherDelegate methods
 
     func changedConnectionState(from old: ConnectionState, to new: ConnectionState) {

--- a/Consumption-Tests/Shared/Swift/iOS/AppDelegate.swift
+++ b/Consumption-Tests/Shared/Swift/iOS/AppDelegate.swift
@@ -6,19 +6,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     #if swift(>=4.2)
-    
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 
         return true
     }
-    
+
     #else
-    
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]? = nil) -> Bool {
 
         return true
     }
-    
+
     #endif
-    
+
 }

--- a/Consumption-Tests/Shared/Swift/iOS/ViewController.swift
+++ b/Consumption-Tests/Shared/Swift/iOS/ViewController.swift
@@ -21,5 +21,5 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         self.pusher = makeAndLaunchPusher()
     }
-    
+
 }

--- a/Consumption-Tests/Shared/Swift/macOS/AppDelegate.swift
+++ b/Consumption-Tests/Shared/Swift/macOS/AppDelegate.swift
@@ -3,8 +3,6 @@ import Cocoa
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
 
-
-
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
@@ -13,6 +11,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Insert code here to tear down your application
     }
 
-
 }
-

--- a/Consumption-Tests/Shared/Swift/tvOS/AppDelegate.swift
+++ b/Consumption-Tests/Shared/Swift/tvOS/AppDelegate.swift
@@ -1,11 +1,9 @@
-
 import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -29,6 +27,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-
 }
-

--- a/Consumption-Tests/Shared/Swift/tvOS/ViewController.swift
+++ b/Consumption-Tests/Shared/Swift/tvOS/ViewController.swift
@@ -21,5 +21,5 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         self.pusher = makeAndLaunchPusher()
     }
-    
+
 }

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 				33831C861A9CF61600B124F1 /* Headers */,
 				33831C871A9CF61600B124F1 /* Resources */,
 				50355EA8A07B4B8038A4DDF1 /* Frameworks */,
+				5333AD0824F928F1006E8DF0 /* Run SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -396,6 +397,7 @@
 				73D8A1F72435E5F3001FDE05 /* Headers */,
 				73D8A1F92435E5F3001FDE05 /* Resources */,
 				73D8A1FA2435E5F3001FDE05 /* Frameworks */,
+				5333AD0924F92916006E8DF0 /* Run SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -519,6 +521,42 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "case \"$PLATFORM_NAME\" in\nmacosx) plat=Mac;;\niphone*) plat=iOS;;\nwatch*) plat=watchOS;;\ntv*) plat=tvOS;;\nappletv*) plat=tvOS;;\n*) echo \"error: Unknown PLATFORM_NAME: $PLATFORM_NAME\"; exit 1;;\nesac\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nframework=$(basename \"${!VAR}\")\nexport SCRIPT_INPUT_FILE_$n=\"$SRCROOT\"/Carthage/Build/$plat/\"$framework\".framework\ndone\n\n/usr/local/bin/carthage copy-frameworks || exit\n\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nsource=${!VAR}.dSYM\ndest=${BUILT_PRODUCTS_DIR}/$(basename \"$source\")\nditto \"$source\" \"$dest\" || exit\ndone\n";
+		};
+		5333AD0824F928F1006E8DF0 /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		5333AD0924F92916006E8DF0 /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		73D8A2222435F24E001FDE05 /* Copy Carthage Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -358,6 +358,7 @@
 				33831C861A9CF61600B124F1 /* Headers */,
 				33831C871A9CF61600B124F1 /* Resources */,
 				50355EA8A07B4B8038A4DDF1 /* Frameworks */,
+				5333AD0A24FE4A8C006E8DF0 /* Run SwiftLint autocorrect */,
 				5333AD0824F928F1006E8DF0 /* Run SwiftLint */,
 			);
 			buildRules = (
@@ -397,6 +398,7 @@
 				73D8A1F72435E5F3001FDE05 /* Headers */,
 				73D8A1F92435E5F3001FDE05 /* Resources */,
 				73D8A1FA2435E5F3001FDE05 /* Frameworks */,
+				5333AD0B24FE4AAC006E8DF0 /* Run SwiftLint autocorrect */,
 				5333AD0924F92916006E8DF0 /* Run SwiftLint */,
 			);
 			buildRules = (
@@ -557,6 +559,42 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		5333AD0A24FE4A8C006E8DF0 /* Run SwiftLint autocorrect */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint autocorrect";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint autocorrect\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		5333AD0B24FE4AAC006E8DF0 /* Run SwiftLint autocorrect */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint autocorrect";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint autocorrect\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 		73D8A2222435F24E001FDE05 /* Copy Carthage Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Sources/Authorizer.swift
+++ b/Sources/Authorizer.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 @objc public protocol Authorizer {
-    @objc func fetchAuthValue(socketID: String, channelName: String, completionHandler: @escaping (PusherAuth?) -> ())
+    @objc func fetchAuthValue(socketID: String, channelName: String, completionHandler: @escaping (PusherAuth?) -> Void)
 }

--- a/Sources/ObjectiveC.swift
+++ b/Sources/ObjectiveC.swift
@@ -14,7 +14,10 @@ import Foundation
     }
 
     func subscribeToPresenceChannel(channelName: String) -> PusherPresenceChannel {
-        return self.subscribeToPresenceChannel(channelName: channelName, auth: nil, onMemberAdded: nil, onMemberRemoved: nil)
+        return self.subscribeToPresenceChannel(channelName: channelName,
+                                               auth: nil,
+                                               onMemberAdded: nil,
+                                               onMemberRemoved: nil)
     }
 
     func subscribeToPresenceChannel(
@@ -22,7 +25,10 @@ import Foundation
         onMemberAdded: ((PusherPresenceChannelMember) -> Void)? = nil,
         onMemberRemoved: ((PusherPresenceChannelMember) -> Void)? = nil
     ) -> PusherPresenceChannel {
-        return self.subscribeToPresenceChannel(channelName: channelName, auth: nil, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
+        return self.subscribeToPresenceChannel(channelName: channelName,
+                                               auth: nil,
+                                               onMemberAdded: onMemberAdded,
+                                               onMemberRemoved: onMemberRemoved)
     }
 
     convenience init(withAppKey key: String, options: PusherClientOptions) {

--- a/Sources/ObjectiveC.swift
+++ b/Sources/ObjectiveC.swift
@@ -7,8 +7,8 @@ import Foundation
 
     func subscribe(
         channelName: String,
-        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
-        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
+        onMemberAdded: ((PusherPresenceChannelMember) -> Void)? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> Void)? = nil
     ) -> PusherChannel {
         return self.subscribe(channelName, auth: nil, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
     }
@@ -19,8 +19,8 @@ import Foundation
 
     func subscribeToPresenceChannel(
         channelName: String,
-        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
-        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
+        onMemberAdded: ((PusherPresenceChannelMember) -> Void)? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> Void)? = nil
     ) -> PusherPresenceChannel {
         return self.subscribeToPresenceChannel(channelName: channelName, auth: nil, onMemberAdded: onMemberAdded, onMemberRemoved: onMemberRemoved)
     }
@@ -105,7 +105,6 @@ import Foundation
     }
 }
 
-
 public extension PusherHost {
     func toObjc() -> OCPusherHost {
         switch self {
@@ -117,7 +116,7 @@ public extension PusherHost {
     }
 
     static func fromObjc(source: OCPusherHost) -> PusherHost {
-        switch (source.type) {
+        switch source.type {
         case 0: return PusherHost.host(source.host!)
         case 1: return PusherHost.cluster(source.cluster!)
         default: return PusherHost.host("ws.pusherapp.com")
@@ -128,8 +127,8 @@ public extension PusherHost {
 @objcMembers
 @objc public class OCPusherHost: NSObject {
     var type: Int
-    var host: String? = nil
-    var cluster: String? = nil
+    var host: String?
+    var cluster: String?
 
     public override init() {
         self.type = 2
@@ -163,7 +162,7 @@ public extension AuthMethod {
     }
 
     static func fromObjc(source: OCAuthMethod) -> AuthMethod {
-        switch (source.type) {
+        switch source.type {
         case 0: return AuthMethod.endpoint(authEndpoint: source.authEndpoint!)
         case 1: return AuthMethod.authRequestBuilder(authRequestBuilder: source.authRequestBuilder!)
         case 2: return AuthMethod.inline(secret: source.secret!)
@@ -177,10 +176,10 @@ public extension AuthMethod {
 @objcMembers
 @objc public class OCAuthMethod: NSObject {
     var type: Int
-    var secret: String? = nil
-    var authEndpoint: String? = nil
-    var authRequestBuilder: AuthRequestBuilderProtocol? = nil
-    var authorizer: Authorizer? = nil
+    var secret: String?
+    var authEndpoint: String?
+    var authRequestBuilder: AuthRequestBuilderProtocol?
+    var authorizer: Authorizer?
 
     public init(type: Int) {
         self.type = type

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -10,9 +10,9 @@ public enum PusherChannelType {
     }
 
     public static func type(forName name: String) -> PusherChannelType {
-        if (name.components(separatedBy: "-")[0] == "presence") {
+        if name.components(separatedBy: "-")[0] == "presence" {
             return .presence
-        } else if (name.components(separatedBy: "-")[0] == "private") {
+        } else if name.components(separatedBy: "-")[0] == "private" {
             return .private
         } else {
             return .normal
@@ -36,7 +36,7 @@ open class PusherChannel: NSObject {
 
     // Wrap accesses to the decryption key in a serial queue because it will be accessed from multiple threads
     @nonobjc private var decryptionKeyQueue = DispatchQueue(label: "com.pusher.pusherswift-channel-decryption-key-\(UUID().uuidString)")
-    @nonobjc private var decryptionKeyInternal: String? = nil
+    @nonobjc private var decryptionKeyInternal: String?
     @nonobjc internal var decryptionKey: String? {
         get {
             return decryptionKeyQueue.sync { decryptionKeyInternal }
@@ -95,7 +95,7 @@ open class PusherChannel: NSObject {
                 callbackData = event.raw["data"]
             }
             callback(callbackData)
-        });
+        })
     }
 
     /**

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -173,7 +173,8 @@ open class PusherChannel: NSObject {
     open func trigger(eventName: String, data: Any) {
         if PusherEncryptionHelpers.isEncryptedChannel(channelName: self.name) {
             let error = """
-            ERROR: Client events are not supported on encrypted channels: '\(self.name)'. Client event '\(eventName)' will not be sent.
+            ERROR: Client events are not supported on encrypted channels: '\(self.name)'. \
+            Client event '\(eventName)' will not be sent.
             """
             print(error)
             return

--- a/Sources/PusherChannel.swift
+++ b/Sources/PusherChannel.swift
@@ -157,6 +157,7 @@ open class PusherChannel: NSObject {
     open func handleEvent(event: PusherEvent) {
         if let eventHandlerArray = self.eventHandlers[event.eventName] {
             for eventHandler in eventHandlerArray {
+                // swiftlint:disable:next force_cast
                 eventHandler.callback(event.copy() as! PusherEvent)
             }
         }

--- a/Sources/PusherChannels.swift
+++ b/Sources/PusherChannels.swift
@@ -23,8 +23,8 @@ import Foundation
         name: String,
         connection: PusherConnection,
         auth: PusherAuth? = nil,
-        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
-        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
+        onMemberAdded: ((PusherPresenceChannelMember) -> Void)? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> Void)? = nil
     ) -> PusherChannel {
         if let channel = self.channels[name] {
             return channel
@@ -65,8 +65,8 @@ import Foundation
         channelName: String,
         connection: PusherConnection,
         auth: PusherAuth? = nil,
-        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
-        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
+        onMemberAdded: ((PusherPresenceChannelMember) -> Void)? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> Void)? = nil
     ) -> PusherPresenceChannel {
         if let channel = self.channels[channelName] as? PusherPresenceChannel {
             return channel

--- a/Sources/PusherClientOptions.swift
+++ b/Sources/PusherClientOptions.swift
@@ -6,8 +6,8 @@ public enum PusherHost {
 
     public var stringValue: String {
         switch self {
-            case .host(let host): return host
-            case .cluster(let cluster): return "ws-\(cluster).pusher.com"
+        case .host(let host): return host
+        case .cluster(let cluster): return "ws-\(cluster).pusher.com"
         }
     }
 }

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -2,7 +2,7 @@ import Foundation
 import Reachability
 import Starscream
 
-//swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length
 
 @objcMembers
 @objc open class PusherConnection: NSObject {

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -43,7 +43,11 @@ import Starscream
         let reachability = try? Reachability()
         reachability?.whenReachable = { [weak self] reachability in
             guard let self = self else {
-                print("Your Pusher instance has probably become deallocated. See https://github.com/pusher/pusher-websocket-swift/issues/109 for more information")
+                print("""
+                    Your Pusher instance has probably become deallocated. \
+                    See https://github.com/pusher/pusher-websocket-swift/issues/109 \
+                    for more information
+                    """)
                 return
             }
 
@@ -72,7 +76,11 @@ import Starscream
         }
         reachability?.whenUnreachable = { [weak self] reachability in
             guard let self = self else {
-                print("Your Pusher instance has probably become deallocated. See https://github.com/pusher/pusher-websocket-swift/issues/109 for more information")
+                print("""
+                    Your Pusher instance has probably become deallocated. \
+                    See https://github.com/pusher/pusher-websocket-swift/issues/109 \
+                    for more information
+                    """)
                 return
             }
 
@@ -487,7 +495,8 @@ import Starscream
 
             if PusherChannelType.isPresenceChannel(name: channelName) {
                 if let presChan = self.channels.find(name: channelName) as? PusherPresenceChannel {
-                    if let dataJSON = event.dataToJSONObject() as? [String: Any], let presenceData = dataJSON["presence"] as? [String: AnyObject],
+                    if let dataJSON = event.dataToJSONObject() as? [String: Any],
+                        let presenceData = dataJSON["presence"] as? [String: AnyObject],
                        let presenceHash = presenceData["hash"] as? [String: AnyObject] {
                         presChan.addExistingMembers(memberHash: presenceHash)
                     }
@@ -524,7 +533,8 @@ import Starscream
             self.reconnectAttempts = 0
             self.reconnectTimer?.invalidate()
 
-            if options.activityTimeout == nil, let activityTimeoutFromServer = connectionData["activity_timeout"] as? TimeInterval {
+            if options.activityTimeout == nil,
+                let activityTimeoutFromServer = connectionData["activity_timeout"] as? TimeInterval {
                 self.activityTimeoutInterval = activityTimeoutFromServer
             }
 
@@ -550,7 +560,8 @@ import Starscream
         - parameter event: The event to be processed
     */
     fileprivate func handleMemberAddedEvent(event: PusherEvent) {
-        if let channelName = event.channelName, let chan = self.channels.find(name: channelName) as? PusherPresenceChannel {
+        if let channelName = event.channelName,
+            let chan = self.channels.find(name: channelName) as? PusherPresenceChannel {
             if let memberJSON = event.dataToJSONObject() as? [String: Any] {
                 chan.addMember(memberJSON: memberJSON)
             } else {
@@ -565,7 +576,8 @@ import Starscream
         - parameter event: The event to be processed
     */
     fileprivate func handleMemberRemovedEvent(event: PusherEvent) {
-        if let channelName = event.channelName, let chan = self.channels.find(name: channelName) as? PusherPresenceChannel {
+        if let channelName = event.channelName,
+            let chan = self.channels.find(name: channelName) as? PusherPresenceChannel {
             if let memberJSON = event.dataToJSONObject() as? [String: Any] {
                 chan.removeMember(memberJSON: memberJSON)
             } else {
@@ -607,7 +619,10 @@ import Starscream
             if let message = error.message {
                 print(message)
             }
-            self.delegate?.failedToSubscribeToChannel?(name: channelName, response: error.response, data: error.data, error: error.error)
+            self.delegate?.failedToSubscribeToChannel?(name: channelName,
+                                                       response: error.response,
+                                                       data: error.data,
+                                                       error: error.error)
         }
     }
 
@@ -682,7 +697,8 @@ import Starscream
         }
     }
 
-    fileprivate func requestPusherAuthFromAuthMethod(channel: PusherChannel, completionHandler:@escaping (PusherAuth?, PusherAuthError?) -> Void) -> Bool {
+    fileprivate func requestPusherAuthFromAuthMethod(channel: PusherChannel,
+                                                     completionHandler: @escaping (PusherAuth?, PusherAuthError?) -> Void) -> Bool {
         guard let socketId = self.socketId else {
             let message = "socketId value not found. You may not be connected."
             completionHandler(nil, PusherAuthError(kind: .notConnected, message: message))
@@ -692,7 +708,9 @@ import Starscream
         switch self.options.authMethod {
         case .noMethod:
             let errorMessage = "Authentication method required for private / presence channels but none provided."
-            let error = NSError(domain: "com.pusher.PusherSwift", code: 0, userInfo: [NSLocalizedFailureReasonErrorKey: errorMessage])
+            let error = NSError(domain: "com.pusher.PusherSwift",
+                                code: 0,
+                                userInfo: [NSLocalizedFailureReasonErrorKey: errorMessage])
             completionHandler(nil, PusherAuthError(kind: .noMethod, message: errorMessage, error: error))
             return false
         case .endpoint(authEndpoint: let authEndpoint):
@@ -705,8 +723,12 @@ import Starscream
                 return true
             } else {
                 let errorMessage = "Authentication request could not be built"
-                let error = NSError(domain: "com.pusher.PusherSwift", code: 0, userInfo: [NSLocalizedFailureReasonErrorKey: errorMessage])
-                completionHandler(nil, PusherAuthError(kind: .couldNotBuildRequest, message: errorMessage, error: error))
+                let error = NSError(domain: "com.pusher.PusherSwift",
+                                    code: 0,
+                                    userInfo: [NSLocalizedFailureReasonErrorKey: errorMessage])
+                completionHandler(nil, PusherAuthError(kind: .couldNotBuildRequest,
+                                                       message: errorMessage,
+                                                       error: error))
                 return false
             }
         case .authorizer(authorizer: let authorizer):
@@ -807,36 +829,53 @@ import Starscream
         - parameter request: The request to send
         - parameter channel: The PusherChannel to authenticate subsciption for
     */
-    fileprivate func sendAuthorisationRequest(request: URLRequest, channel: PusherChannel, completionHandler: @escaping (PusherAuth?, PusherAuthError?) -> Void) {
+    fileprivate func sendAuthorisationRequest(request: URLRequest,
+                                              channel: PusherChannel,
+                                              completionHandler: @escaping (PusherAuth?, PusherAuthError?) -> Void) {
         let task = URLSession.dataTask(with: request, completionHandler: { data, response, sessionError in
             if let error = sessionError {
                 let message = "Error authorizing channel [\(channel.name)]: \(error)"
-                completionHandler(nil, PusherAuthError(kind: .requestFailure, message: message, response: response, error: error as NSError?))
+                completionHandler(nil, PusherAuthError(kind: .requestFailure,
+                                                       message: message,
+                                                       response: response,
+                                                       error: error as NSError?))
                 return
             }
 
             guard let data = data else {
                 let message = "Error authorizing channel [\(channel.name)]"
-                completionHandler(nil, PusherAuthError(kind: .invalidAuthResponse, message: message, response: response))
+                completionHandler(nil, PusherAuthError(kind: .invalidAuthResponse,
+                                                       message: message,
+                                                       response: response))
                 return
             }
 
-            guard let httpResponse = response as? HTTPURLResponse, (httpResponse.statusCode == 200 || httpResponse.statusCode == 201) else {
+            guard let httpResponse = response as? HTTPURLResponse,
+                (httpResponse.statusCode == 200 || httpResponse.statusCode == 201) else {
                 let dataString = String(data: data, encoding: String.Encoding.utf8)
                 let message = "Error authorizing channel [\(channel.name)]: \(String(describing: dataString))"
-                completionHandler(nil, PusherAuthError(kind: .invalidAuthResponse, message: message, response: response, data: dataString))
+                completionHandler(nil, PusherAuthError(kind: .invalidAuthResponse,
+                                                       message: message,
+                                                       response: response,
+                                                       data: dataString))
                 return
             }
 
-            guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []), let json = jsonObject as? [String: AnyObject] else {
+            guard let jsonObject = try? JSONSerialization.jsonObject(with: data,
+                                                                     options: []),
+                let json = jsonObject as? [String: AnyObject] else {
                 let message = "Error authorizing channel [\(channel.name)]: Could not parse response from auth endpoint"
-                completionHandler(nil, PusherAuthError(kind: .invalidAuthResponse, message: message, response: httpResponse))
+                completionHandler(nil, PusherAuthError(kind: .invalidAuthResponse,
+                                                       message: message,
+                                                       response: httpResponse))
                 return
             }
 
             guard let auth = json["auth"] as? String else {
                 let message = "Error authorizing channel [\(channel.name)]: No auth field in response"
-                completionHandler(nil, PusherAuthError(kind: .invalidAuthResponse, message: message, response: httpResponse))
+                completionHandler(nil, PusherAuthError(kind: .invalidAuthResponse,
+                                                       message: message,
+                                                       response: httpResponse))
                 return
             }
 
@@ -919,7 +958,9 @@ extension PusherConnection: PusherEventQueueDelegate {
         }
     }
 
-    func eventQueue(_ eventQueue: PusherEventQueue, didFailToDecryptEventWithPayload payload: PusherEventPayload, forChannelName channelName: String) {
+    func eventQueue(_ eventQueue: PusherEventQueue,
+                    didFailToDecryptEventWithPayload payload: PusherEventPayload,
+                    forChannelName channelName: String) {
         DispatchQueue.main.async {
             if let eventName = payload["event"] as? String {
                 let data = payload["data"] as? String
@@ -929,7 +970,9 @@ extension PusherConnection: PusherEventQueueDelegate {
         }
     }
 
-    func eventQueue(_ eventQueue: PusherEventQueue, didReceiveEvent event: PusherEvent, forChannelName channelName: String?) {
+    func eventQueue(_ eventQueue: PusherEventQueue,
+                    didReceiveEvent event: PusherEvent,
+                    forChannelName channelName: String?) {
         DispatchQueue.main.async {
             self.handleEvent(event: event)
         }

--- a/Sources/PusherConnection.swift
+++ b/Sources/PusherConnection.swift
@@ -2,6 +2,8 @@ import Foundation
 import Reachability
 import Starscream
 
+//swiftlint:disable file_length type_body_length
+
 @objcMembers
 @objc open class PusherConnection: NSObject {
     public let url: String

--- a/Sources/PusherCrypto.swift
+++ b/Sources/PusherCrypto.swift
@@ -20,7 +20,12 @@ struct PusherCrypto {
         _ = digest.withUnsafeMutableBytes { (digestBytes: UnsafeMutableRawBufferPointer) in
             _ = secretData.withUnsafeBytes { (secretBytes: UnsafeRawBufferPointer) in
                 _ = messageData.withUnsafeBytes { (messageBytes: UnsafeRawBufferPointer) in
-                    CCHmac(algorithm, secretBytes.baseAddress, secretData.count, messageBytes.baseAddress, messageData.count, digestBytes.baseAddress)
+                    CCHmac(algorithm,
+                           secretBytes.baseAddress,
+                           secretData.count,
+                           messageBytes.baseAddress,
+                           messageData.count,
+                           digestBytes.baseAddress)
                 }
             }
         }

--- a/Sources/PusherError.swift
+++ b/Sources/PusherError.swift
@@ -3,7 +3,8 @@ import Foundation
 @objcMembers
 open class PusherError: NSObject {
 
-    // Code is optional, message is not: https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#-pusher-error-channels-client-
+    /// Code is optional, message is not:
+    /// https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#-pusher-error-channels-client-
     /// The error code.
     public let code: Int?
     /// The error message.

--- a/Sources/PusherEvent.swift
+++ b/Sources/PusherEvent.swift
@@ -6,11 +6,13 @@ open class PusherEvent: NSObject, NSCopying {
     /// The JSON object received from the websocket
     @nonobjc internal let raw: [String: Any]
 
-    // According to Channels protocol, there is always an event https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
+    /// According to Channels protocol, there is always an event
+    /// https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#events
     /// The name of the event.
     public let eventName: String
 
-    /// The name of the channel that the event was triggered on. Not present in events without an associated channel, e.g. "pusher:error" events relating to the connection.
+    /// The name of the channel that the event was triggered on.
+    /// Not present in events without an associated channel, e.g. "pusher:error" events relating to the connection.
     public let channelName: String?
 
     /// The data that was passed when the event was triggered.
@@ -19,7 +21,11 @@ open class PusherEvent: NSObject, NSCopying {
     /// The ID of the user who triggered the event. Only present in client event on presence channels.
     public let userId: String?
 
-    @nonobjc internal init(eventName: String, channelName: String?, data: String?, userId: String?, raw: [String: Any]) {
+    @nonobjc internal init(eventName: String,
+                           channelName: String?,
+                           data: String?,
+                           userId: String?,
+                           raw: [String: Any]) {
         self.eventName = eventName
         self.channelName = channelName
         self.data = data
@@ -65,11 +71,19 @@ open class PusherEvent: NSObject, NSCopying {
     @nonobjc internal func copy(withEventName eventName: String) -> PusherEvent {
         var jsonObject = self.raw
         jsonObject["event"] = eventName
-        return PusherEvent(eventName: eventName, channelName: self.channelName, data: self.data, userId: self.userId, raw: jsonObject)
+        return PusherEvent(eventName: eventName,
+                           channelName: self.channelName,
+                           data: self.data,
+                           userId: self.userId,
+                           raw: jsonObject)
     }
 
     public func copy(with zone: NSZone? = nil) -> Any {
-        return PusherEvent(eventName: self.eventName, channelName: self.channelName, data: self.data, userId: self.userId, raw: self.raw)
+        return PusherEvent(eventName: self.eventName,
+                           channelName: self.channelName,
+                           data: self.data,
+                           userId: self.userId,
+                           raw: self.raw)
     }
 
 }

--- a/Sources/PusherEventFactory.swift
+++ b/Sources/PusherEventFactory.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 protocol PusherEventFactory {
-    
+
     func makeEvent(fromJSON json: PusherEventPayload, withDecryptionKey decryptionKey: String?) throws -> PusherEvent
-    
+
 }
 
 // MARK: - Concrete implementation
@@ -11,33 +11,31 @@ protocol PusherEventFactory {
 struct PusherConcreteEventFactory: PusherEventFactory {
 
     // MARK: - Event factory
-    
+
     func makeEvent(fromJSON json: PusherEventPayload, withDecryptionKey decryptionKey: String? = nil) throws -> PusherEvent {
         guard let eventName = json["event"] as? String else {
             throw PusherEventError.invalidFormat
         }
-        
+
         let channelName = json["channel"] as? String
         let data = try self.data(fromJSON: json, eventName: eventName, channelName: channelName, decryptionKey: decryptionKey)
         let userId = json["user_id"] as? String
-        
+
         return PusherEvent(eventName: eventName, channelName: channelName, data: data, userId: userId, raw: json)
     }
-    
+
     // MARK: - Private methods
-    
+
     private func data(fromJSON json: PusherEventPayload, eventName: String, channelName: String?, decryptionKey: String?) throws -> String? {
         let data = json["data"] as? String
-        
+
         if PusherEncryptionHelpers.shouldDecryptMessage(eventName: eventName, channelName: channelName) {
             return try PusherDecryptor.decrypt(data: data, decryptionKey: decryptionKey)
-        }
-        else {
+        } else {
             return data
         }
     }
 }
-
 
 // MARK: - Types
 
@@ -46,9 +44,9 @@ typealias PusherEventPayload = [String: Any]
 // MARK: - Error handling
 
 enum PusherEventError: Error {
-    
+
     case invalidFormat
     case invalidDecryptionKey
     case invalidEncryptedData
-    
+
 }

--- a/Sources/PusherEventFactory.swift
+++ b/Sources/PusherEventFactory.swift
@@ -12,13 +12,17 @@ struct PusherConcreteEventFactory: PusherEventFactory {
 
     // MARK: - Event factory
 
-    func makeEvent(fromJSON json: PusherEventPayload, withDecryptionKey decryptionKey: String? = nil) throws -> PusherEvent {
+    func makeEvent(fromJSON json: PusherEventPayload,
+                   withDecryptionKey decryptionKey: String? = nil) throws -> PusherEvent {
         guard let eventName = json["event"] as? String else {
             throw PusherEventError.invalidFormat
         }
 
         let channelName = json["channel"] as? String
-        let data = try self.data(fromJSON: json, eventName: eventName, channelName: channelName, decryptionKey: decryptionKey)
+        let data = try self.data(fromJSON: json,
+                                 eventName: eventName,
+                                 channelName: channelName,
+                                 decryptionKey: decryptionKey)
         let userId = json["user_id"] as? String
 
         return PusherEvent(eventName: eventName, channelName: channelName, data: data, userId: userId, raw: json)
@@ -26,7 +30,10 @@ struct PusherConcreteEventFactory: PusherEventFactory {
 
     // MARK: - Private methods
 
-    private func data(fromJSON json: PusherEventPayload, eventName: String, channelName: String?, decryptionKey: String?) throws -> String? {
+    private func data(fromJSON json: PusherEventPayload,
+                      eventName: String,
+                      channelName: String?,
+                      decryptionKey: String?) throws -> String? {
         let data = json["data"] as? String
 
         if PusherEncryptionHelpers.shouldDecryptMessage(eventName: eventName, channelName: channelName) {

--- a/Sources/PusherEventQueue.swift
+++ b/Sources/PusherEventQueue.swift
@@ -58,7 +58,9 @@ class PusherConcreteEventQueue: PusherEventQueue {
                 do {
                     try self.processEvent(json: json, channel: channel)
                 } catch {
-                    self.delegate?.eventQueue(self, didFailToDecryptEventWithPayload: json, forChannelName: channel.name)
+                    self.delegate?.eventQueue(self,
+                                              didFailToDecryptEventWithPayload: json,
+                                              forChannelName: channel.name)
                 }
             }
         } catch PusherEventError.invalidEncryptedData {
@@ -81,9 +83,15 @@ class PusherConcreteEventQueue: PusherEventQueue {
 
 protocol PusherEventQueueDelegate: AnyObject {
 
-    func eventQueue(_ eventQueue: PusherEventQueue, didReceiveEvent event: PusherEvent, forChannelName channelName: String?)
-    func eventQueue(_ eventQueue: PusherEventQueue, didFailToDecryptEventWithPayload payload: PusherEventPayload, forChannelName channelName: String)
-    func eventQueue(_ eventQueue: PusherEventQueue, didReceiveInvalidEventWithPayload payload: PusherEventPayload)
-    func eventQueue(_ eventQueue: PusherEventQueue, reloadDecryptionKeySyncForChannel channel: PusherChannel)
+    func eventQueue(_ eventQueue: PusherEventQueue,
+                    didReceiveEvent event: PusherEvent,
+                    forChannelName channelName: String?)
+    func eventQueue(_ eventQueue: PusherEventQueue,
+                    didFailToDecryptEventWithPayload payload: PusherEventPayload,
+                    forChannelName channelName: String)
+    func eventQueue(_ eventQueue: PusherEventQueue,
+                    didReceiveInvalidEventWithPayload payload: PusherEventPayload)
+    func eventQueue(_ eventQueue: PusherEventQueue,
+                    reloadDecryptionKeySyncForChannel channel: PusherChannel)
 
 }

--- a/Sources/PusherEventQueue.swift
+++ b/Sources/PusherEventQueue.swift
@@ -1,35 +1,35 @@
 import Foundation
 
 protocol PusherEventQueue {
-    
+
     var delegate: PusherEventQueueDelegate? { get set }
 
     func enqueue(json: PusherEventPayload)
-    
+
 }
 
 // MARK: - Concrete implementation
 
 class PusherConcreteEventQueue: PusherEventQueue {
-    
+
     // MARK: - Properties
-    
+
     private let eventFactory: PusherEventFactory
     private let channels: PusherChannels
     private var queue = DispatchQueue(label: "com.pusher.pusherswift-event-queue-\(UUID().uuidString)")
-    
+
     weak var delegate: PusherEventQueueDelegate?
-    
+
     // MARK: - Initializers
-    
+
     init(eventFactory: PusherEventFactory, channels: PusherChannels) {
         self.eventFactory = eventFactory
         self.channels = channels
     }
-    
+
     // MARK: - Event queue
     public func enqueue(json: PusherEventPayload) {
-        var channel: PusherChannel? = nil
+        var channel: PusherChannel?
 
         // If this event is for a particular channel, find the channel
         if let channelName = json["channel"] as? String {
@@ -57,7 +57,7 @@ class PusherConcreteEventQueue: PusherEventQueue {
                 self.delegate?.eventQueue(self, reloadDecryptionKeySyncForChannel: channel)
                 do {
                     try self.processEvent(json: json, channel: channel)
-                }catch {
+                } catch {
                     self.delegate?.eventQueue(self, didFailToDecryptEventWithPayload: json, forChannelName: channel.name)
                 }
             }
@@ -80,10 +80,10 @@ class PusherConcreteEventQueue: PusherEventQueue {
 // MARK: - Delegate
 
 protocol PusherEventQueueDelegate: AnyObject {
-    
+
     func eventQueue(_ eventQueue: PusherEventQueue, didReceiveEvent event: PusherEvent, forChannelName channelName: String?)
     func eventQueue(_ eventQueue: PusherEventQueue, didFailToDecryptEventWithPayload payload: PusherEventPayload, forChannelName channelName: String)
     func eventQueue(_ eventQueue: PusherEventQueue, didReceiveInvalidEventWithPayload payload: PusherEventPayload)
     func eventQueue(_ eventQueue: PusherEventQueue, reloadDecryptionKeySyncForChannel channel: PusherChannel)
-    
+
 }

--- a/Sources/PusherGlobalChannel.swift
+++ b/Sources/PusherGlobalChannel.swift
@@ -23,6 +23,7 @@ import Foundation
     */
     internal func handleGlobalEvent(event: PusherEvent) {
         for (_, callback) in self.globalCallbacks {
+            // swiftlint:disable:next force_cast
             callback(event.copy() as! PusherEvent)
         }
     }

--- a/Sources/PusherGlobalChannel.swift
+++ b/Sources/PusherGlobalChannel.swift
@@ -38,7 +38,6 @@ import Foundation
         }
     }
 
-
     /**
         Binds a callback to the global channel
 

--- a/Sources/PusherParser.swift
+++ b/Sources/PusherParser.swift
@@ -15,7 +15,9 @@ internal struct PusherParser {
         let data = (string as NSString).data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false)
 
         do {
-            if let jsonData = data, let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: AnyObject] {
+            if let jsonData = data,
+                let jsonObject = try JSONSerialization.jsonObject(with: jsonData,
+                                                                  options: []) as? [String: AnyObject] {
                 return jsonObject
             } else {
                 print("Unable to parse string from WebSocket: \(string)")

--- a/Sources/PusherPresenceChannel.swift
+++ b/Sources/PusherPresenceChannel.swift
@@ -56,7 +56,8 @@ public typealias PusherUserInfoObject = [String: AnyObject]
             }
         } else {
             if let userInfo = memberJSON["user_info"] as? PusherUserInfoObject {
-                member = PusherPresenceChannelMember(userId: String.init(describing: memberJSON["user_id"]!), userInfo: userInfo as AnyObject?)
+                member = PusherPresenceChannelMember(userId: String.init(describing: memberJSON["user_id"]!),
+                                                     userInfo: userInfo as AnyObject?)
             } else {
                 member = PusherPresenceChannelMember(userId: String.init(describing: memberJSON["user_id"]!))
             }
@@ -131,7 +132,9 @@ public typealias PusherUserInfoObject = [String: AnyObject]
         let data = (channelData as NSString).data(using: String.Encoding.utf8.rawValue, allowLossyConversion: false)
 
         do {
-            if let jsonData = data, let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: AnyObject] {
+            if let jsonData = data,
+                let jsonObject = try JSONSerialization.jsonObject(with: jsonData,
+                                                                  options: []) as? [String: AnyObject] {
                 return jsonObject
             } else {
                 print("Unable to parse string: \(channelData)")

--- a/Sources/PusherPresenceChannel.swift
+++ b/Sources/PusherPresenceChannel.swift
@@ -5,9 +5,9 @@ public typealias PusherUserInfoObject = [String: AnyObject]
 @objcMembers
 @objc open class PusherPresenceChannel: PusherChannel {
     open var members: [PusherPresenceChannelMember]
-    open var onMemberAdded: ((PusherPresenceChannelMember) -> ())?
-    open var onMemberRemoved: ((PusherPresenceChannelMember) -> ())?
-    open var myId: String? = nil
+    open var onMemberAdded: ((PusherPresenceChannelMember) -> Void)?
+    open var onMemberRemoved: ((PusherPresenceChannelMember) -> Void)?
+    open var myId: String?
 
     /**
         Initializes a new PusherPresenceChannel with a given name, conenction, and optional
@@ -28,8 +28,8 @@ public typealias PusherUserInfoObject = [String: AnyObject]
         name: String,
         connection: PusherConnection,
         auth: PusherAuth? = nil,
-        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
-        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
+        onMemberAdded: ((PusherPresenceChannelMember) -> Void)? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> Void)? = nil
     ) {
         self.members = []
         self.onMemberAdded = onMemberAdded
@@ -44,7 +44,7 @@ public typealias PusherUserInfoObject = [String: AnyObject]
         - parameter memberJSON: A dictionary representing the member that has joined
                                 the presence channel
     */
-    internal func addMember(memberJSON: [String : Any]) {
+    internal func addMember(memberJSON: [String: Any]) {
         let member: PusherPresenceChannelMember
 
         if let userId = memberJSON["user_id"] as? String {
@@ -72,7 +72,7 @@ public typealias PusherUserInfoObject = [String: AnyObject]
         - parameter memberHash: A dictionary representing the members that were already
                                 subscribed to the presence channel
     */
-    internal func addExistingMembers(memberHash: [String : AnyObject]) {
+    internal func addExistingMembers(memberHash: [String: AnyObject]) {
         for (userId, userInfo) in memberHash {
             let member: PusherPresenceChannelMember
             if let userInfo = userInfo as? PusherUserInfoObject {
@@ -91,7 +91,7 @@ public typealias PusherUserInfoObject = [String: AnyObject]
         - parameter memberJSON: A dictionary representing the member that has left the
                                 presence channel
     */
-    internal func removeMember(memberJSON: [String : Any]) {
+    internal func removeMember(memberJSON: [String: Any]) {
         let id: String
 
         if let userId = memberJSON["user_id"] as? String {
@@ -141,7 +141,6 @@ public typealias PusherUserInfoObject = [String: AnyObject]
         }
         return nil
     }
-
 
     /**
         Returns the PusherPresenceChannelMember object for the given user id

--- a/Sources/PusherSwift-Only/PusherDecryptor.swift
+++ b/Sources/PusherSwift-Only/PusherDecryptor.swift
@@ -1,4 +1,3 @@
-
 class PusherDecryptor {
 
     static func decrypt(data dataAsString: String?, decryptionKey: String?) throws -> String? {
@@ -8,5 +7,5 @@ class PusherDecryptor {
     static func isDecryptionAvailable() -> Bool {
         return false
     }
-    
+
 }

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -3,7 +3,7 @@ import Starscream
 
 let PROTOCOL = 7
 let VERSION = "8.0.0"
-//swiftlint:disable:next identifier_name
+// swiftlint:disable:next identifier_name
 let CLIENT_NAME = "pusher-websocket-swift"
 
 @objcMembers

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -47,13 +47,13 @@ let CLIENT_NAME = "pusher-websocket-swift"
     open func subscribe(
         _ channelName: String,
         auth: PusherAuth? = nil,
-        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
-        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
+        onMemberAdded: ((PusherPresenceChannelMember) -> Void)? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> Void)? = nil
     ) -> PusherChannel {
 
         let isEncryptedChannel = PusherEncryptionHelpers.isEncryptedChannel(channelName: channelName)
 
-        if isEncryptedChannel && !PusherDecryptor.isDecryptionAvailable(){
+        if isEncryptedChannel && !PusherDecryptor.isDecryptionAvailable() {
             let error = """
 
             WARNING: You are subscribing to an encrypted channel: '\(channelName)' but this version of PusherSwift does not \
@@ -100,8 +100,8 @@ let CLIENT_NAME = "pusher-websocket-swift"
     open func subscribeToPresenceChannel(
         channelName: String,
         auth: PusherAuth? = nil,
-        onMemberAdded: ((PusherPresenceChannelMember) -> ())? = nil,
-        onMemberRemoved: ((PusherPresenceChannelMember) -> ())? = nil
+        onMemberAdded: ((PusherPresenceChannelMember) -> Void)? = nil,
+        onMemberRemoved: ((PusherPresenceChannelMember) -> Void)? = nil
     ) -> PusherPresenceChannel {
         return self.connection.subscribeToPresenceChannel(
             channelName: channelName,

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -3,6 +3,7 @@ import Starscream
 
 let PROTOCOL = 7
 let VERSION = "8.0.0"
+//swiftlint:disable:next identifier_name
 let CLIENT_NAME = "pusher-websocket-swift"
 
 @objcMembers

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -56,8 +56,9 @@ let CLIENT_NAME = "pusher-websocket-swift"
         if isEncryptedChannel && !PusherDecryptor.isDecryptionAvailable() {
             let error = """
 
-            WARNING: You are subscribing to an encrypted channel: '\(channelName)' but this version of PusherSwift does not \
-            support end-to-end encryption. Events will not be decrypted. You must import 'PusherSwiftWithEncryption' in \
+            WARNING: You are subscribing to an encrypted channel: '\(channelName)' but this \
+            version of PusherSwift does not support end-to-end encryption. \
+            Events will not be decrypted. You must import 'PusherSwiftWithEncryption' in \
             order for events to be decrypted. See https://github.com/pusher/pusher-websocket-swift for more information
 
             """
@@ -67,8 +68,9 @@ let CLIENT_NAME = "pusher-websocket-swift"
         if isEncryptedChannel && auth != nil {
             let error = """
 
-            WARNING: Passing an auth value to 'subscribe' is not supported for encrypted channels. Event decryption will \
-            fail. You must use one of the following auth methods: 'endpoint', 'authRequestBuilder', 'authorizer'
+            WARNING: Passing an auth value to 'subscribe' is not supported for encrypted channels. \
+            Event decryption will fail. You must use one of the following auth methods: \
+            'endpoint', 'authRequestBuilder', 'authorizer'
 
             """
             print(error)

--- a/Sources/PusherSwiftWithEncryption-Only/PusherDecryptor.swift
+++ b/Sources/PusherSwiftWithEncryption-Only/PusherDecryptor.swift
@@ -24,7 +24,9 @@ class PusherDecryptor {
         let nonce = try self.decodedNonce(fromEncryptedData: encryptedData)
         let secretKey = try self.decodedDecryptionKey(fromDecryptionKey: decryptionKey)
 
-        guard let decryptedData = self.sodium.secretBox.open(authenticatedCipherText: cipherText, secretKey: secretKey, nonce: nonce),
+        guard let decryptedData = self.sodium.secretBox.open(authenticatedCipherText: cipherText,
+                                                             secretKey: secretKey,
+                                                             nonce: nonce),
             let decryptedString = String(bytes: decryptedData, encoding: .utf8) else {
                 throw PusherEventError.invalidDecryptionKey
         }

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,0 +1,3 @@
+disabled_rules:
+  - force_try
+  - force_cast

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,3 +1,4 @@
 disabled_rules:
   - force_try
   - force_cast
+  - line_length

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-//swiftlint:disable nesting
+// swiftlint:disable nesting
 
 #if WITH_ENCRYPTION
     @testable import PusherSwiftWithEncryption

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -8,8 +8,8 @@ import XCTest
 
 class AuthenticationTests: XCTestCase {
     class DummyDelegate: PusherDelegate {
-        var ex: XCTestExpectation? = nil
-        var testingChannelName: String? = nil
+        var ex: XCTestExpectation?
+        var testingChannelName: String?
 
         func subscribedToChannel(name: String) {
             if let cName = testingChannelName, cName == name {
@@ -127,7 +127,7 @@ class AuthenticationTests: XCTestCase {
         let chan = pusher.subscribe("private-test-channel")
         XCTAssertFalse(chan.subscribed, "the channel should not be subscribed")
 
-        let _ = pusher.bind({ (data: Any?) -> Void in
+        _ = pusher.bind({ (data: Any?) -> Void in
             if let data = data as? [String: AnyObject], let eventName = data["event"] as? String, eventName == "pusher:subscription_error" {
                 XCTAssertEqual("private-test-channel", data["channel"] as? String)
                 XCTAssertTrue(Thread.isMainThread)
@@ -221,7 +221,7 @@ class AuthenticationTests: XCTestCase {
     func testAuthorizationUsingSomethingConformingToTheAuthorizerProtocol() {
 
         class SomeAuthorizer: Authorizer {
-            func fetchAuthValue(socketID: String, channelName: String, completionHandler: @escaping (PusherAuth?) -> ()) {
+            func fetchAuthValue(socketID: String, channelName: String, completionHandler: @escaping (PusherAuth?) -> Void) {
                 completionHandler(PusherAuth(auth: "testKey123:authorizerblah123"))
             }
         }
@@ -252,7 +252,7 @@ class AuthenticationTests: XCTestCase {
     func testAuthorizationOfPresenceChannelSubscriptionUsingSomethingConformingToTheAuthorizerProtocol() {
 
         class SomeAuthorizer: Authorizer {
-            func fetchAuthValue(socketID: String, channelName: String, completionHandler: @escaping (PusherAuth?) -> ()) {
+            func fetchAuthValue(socketID: String, channelName: String, completionHandler: @escaping (PusherAuth?) -> Void) {
                 completionHandler(PusherAuth(
                     auth: "testKey123:authorizerblah1234",
                     channelData: "{\"user_id\":\"777\", \"user_info\":{\"twitter\":\"hamchapman\"}}"

--- a/Tests/AuthenticationTests.swift
+++ b/Tests/AuthenticationTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 
+//swiftlint:disable nesting
+
 #if WITH_ENCRYPTION
     @testable import PusherSwiftWithEncryption
 #else

--- a/Tests/Helpers.swift
+++ b/Tests/Helpers.swift
@@ -21,7 +21,7 @@ func convertStringToDictionary(_ text: String) -> [String: AnyObject]? {
 extension AuthMethod: Equatable {
 }
 
-public func ==(lhs: AuthMethod, rhs: AuthMethod) -> Bool {
+public func == (lhs: AuthMethod, rhs: AuthMethod) -> Bool {
     switch (lhs, rhs) {
     case (let .endpoint(authEndpoint1), let .endpoint(authEndpoint2)):
         return authEndpoint1 == authEndpoint2

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -294,12 +294,11 @@ public typealias Response = (data: Data?, urlResponse: URLResponse?, error: NSEr
 
 public class MockSession: URLSession {
     static public var mockResponses: [String: Response] = [:]
+    //swiftlint:disable:next large_tuple
     static public var mockResponse: (data: Data?, urlResponse: URLResponse?, error: NSError?) = (data: nil, urlResponse: nil, error: nil)
 
     override public class var shared: URLSession {
-        get {
-            return MockSession()
-        }
+        return MockSession()
     }
 
     override public func dataTask(with: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -57,6 +57,7 @@ open class MockWebSocket: WebSocket {
         )
     }
 
+    //swiftlint:disable:next function_body_length cyclomatic_complexity
     open override func write(string: String, completion: (() -> Void)? = nil) {
         if string == "{\"data\":{\"channel\":\"test-channel\"},\"event\":\"pusher:subscribe\"}" || string == "{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"test-channel\"}}" {
             _ = stubber.stub(

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -57,7 +57,7 @@ open class MockWebSocket: WebSocket {
         )
     }
 
-    //swiftlint:disable:next function_body_length cyclomatic_complexity
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
     open override func write(string: String, completion: (() -> Void)? = nil) {
         if string == "{\"data\":{\"channel\":\"test-channel\"},\"event\":\"pusher:subscribe\"}" || string == "{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"test-channel\"}}" {
             _ = stubber.stub(
@@ -295,7 +295,7 @@ public typealias Response = (data: Data?, urlResponse: URLResponse?, error: NSEr
 
 public class MockSession: URLSession {
     static public var mockResponses: [String: Response] = [:]
-    //swiftlint:disable:next large_tuple
+    // swiftlint:disable:next large_tuple
     static public var mockResponse: (data: Data?, urlResponse: URLResponse?, error: NSError?) = (data: nil, urlResponse: nil, error: nil)
 
     override public class var shared: URLSession {

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -10,8 +10,8 @@ import Starscream
 open class MockWebSocket: WebSocket {
     let stubber = StubberForMocks()
     var callbackCheckString: String = ""
-    var objectGivenToCallback: Any? = nil
-    var eventGivenToCallback: PusherEvent? = nil
+    var objectGivenToCallback: Any?
+    var eventGivenToCallback: PusherEvent?
 
     init() {
         var request = URLRequest(url: URL(string: "test")!)
@@ -33,7 +33,7 @@ open class MockWebSocket: WebSocket {
 
     open override func connect() {
         let connectionEstablishedString = "{\"event\":\"pusher:connection_established\",\"data\":\"{\\\"socket_id\\\":\\\"45481.3166671\\\",\\\"activity_timeout\\\":120}\"}"
-        let _ = stubber.stub(
+        _ = stubber.stub(
             functionName: "connect",
             args: nil,
             functionToCall: {
@@ -48,7 +48,7 @@ open class MockWebSocket: WebSocket {
     }
 
     open override func disconnect(forceTimeout: TimeInterval? = nil, closeCode: UInt16 = CloseCode.normal.rawValue) {
-        let _ = stubber.stub(
+        _ = stubber.stub(
             functionName: "disconnect",
             args: nil,
             functionToCall: {
@@ -57,9 +57,9 @@ open class MockWebSocket: WebSocket {
         )
     }
 
-    open override func write(string: String, completion: (() -> ())? = nil) {
+    open override func write(string: String, completion: (() -> Void)? = nil) {
         if string == "{\"data\":{\"channel\":\"test-channel\"},\"event\":\"pusher:subscribe\"}" || string == "{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"test-channel\"}}" {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -67,7 +67,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if string == "{\"data\":{\"channel\":\"test-channel2\"},\"event\":\"pusher:subscribe\"}" || string == "{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"test-channel2\"}}" {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -75,7 +75,7 @@ open class MockWebSocket: WebSocket {
             }
             )
         } else if stringContainsElements(string, elements: ["testkey123:6aae8814fabd5285245422096705abbed64ea59614648814ffb0bf2dc5d19168", "private-channel", "pusher:subscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -83,7 +83,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["key:5ce61ee2b8594e22b66323913d7c7af9d8e815659365be3627733993f4ce3824", "presence-channel", "user_id", "45481.3166671", "pusher:subscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -91,7 +91,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["testkey123:5ce61ee2b8594e22b66323913d7c7af9d8e815659365be3627733993f4ce3824", "presence-channel", "user_id", "45481.3166671", "pusher:subscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -99,7 +99,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["key:e1d0947a10d6ff1a25990798910b2505687bb096e3e8b6c97eef02c6b1abb4c7", "private-channel", "pusher:subscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -107,13 +107,13 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["data", "testing client events", "private-channel", "client-test-event"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: nil
             )
         } else if stringContainsElements(string, elements: ["testKey123:12345678gfder78ikjbg", "private-test-channel", "pusher:subscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -121,7 +121,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:12345678gfder78ikjbgmanualauth", "private-manual-auth"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -129,7 +129,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:12345678gfder78ikjbgmanualauth", "presence-manual-auth"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -137,7 +137,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["key:0d0d2e7c2cd967246d808180ef0f115dad51979e48cac9ad203928141f9e6a6f", "private-test-channel", "pusher:subscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -145,7 +145,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["private-reservations-for-venue@venue_id=399edd2d-3f4a-43k9-911c-9e4b6bdf0f16;date=2017-01-13", "pusher:subscribe", "testKey123:12345678gfder78ikjbg"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -153,20 +153,20 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["test-channel", "pusher:unsubscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: nil
             )
         } else if stringContainsElements(string, elements: ["test-channel2", "pusher:unsubscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: nil
             )
         } else if stringContainsElements(string, elements: ["presence-test", "user_id", "123", "pusher:subscribe", "user_info", "twitter", "hamchapman"]) && (stringContainsElements(string, elements: ["testkey123:736f0b19c2e56f985f3e6faa38db5b69d39305bc8519952c8f9f5595d69fcb3d"]) || stringContainsElements(string, elements: ["testkey123:e5ee520a16348ced21be557e14ae70fcd1ae89f79d32d14d22a19049eaf56881"])) {
             // We require different auth signatures depending on the ordering of the channel_data JSON/Dictionary
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -174,7 +174,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["key:c2b53f001321bc088814f210fb63c259b464f590890eee2dde6387ea9b469a30", "presence-channel", "user_id", "123", "pusher:subscribe"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -183,7 +183,7 @@ open class MockWebSocket: WebSocket {
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "presence-channel", "friends", "0", "user_id", "123"]) && (stringContainsElements(string, elements: ["key:dd2885ee6dc6f5c964d8e3c720980397db50bf8f528e0630d4208bff80ee23f0"]) || stringContainsElements(string, elements: ["key:80cfefb0ef08fb55353dbbc0480e6160059fac14fce862e9ed1f0121ae8a440f"])) {
             // We require different auth signatures depending on the ordering of the channel_data JSON/Dictionary
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -191,7 +191,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:authorizerblah123", "private-test-channel-authorizer"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -199,7 +199,7 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["pusher:subscribe", "testKey123:authorizerblah1234", "presence-test-channel-authorizer"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
@@ -207,12 +207,12 @@ open class MockWebSocket: WebSocket {
                 }
             )
         } else if stringContainsElements(string, elements: ["private-encrypted-channel", "pusher:subscribe", "636a81ba7e7b15725c00:3ee04892514e8a669dc5d30267221f16727596688894712cad305986e6fc0f3c"]) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "writeString",
                 args: [string],
                 functionToCall: {
                     self.delegate?.websocketDidReceiveMessage(socket: self, text: "{\"event\":\"pusher_internal:subscription_succeeded\",\"channel\":\"private-encrypted-channel\",\"data\":\"{}\"}")
-            } )
+            })
         } else {
             print("No match in write(string: ...) mock for string: \(string)")
         }
@@ -238,7 +238,7 @@ open class MockPusherConnection: PusherConnection {
     }
 
     open override func handleEvent(event: PusherEvent) {
-        let _ = stubber.stub(
+        _ = stubber.stub(
             functionName: "handleEvent",
             args: [event],
             functionToCall: { super.handleEvent(event: event) }
@@ -269,12 +269,12 @@ open class StubberForMocks {
         return nil
     }
 
-    open func registerCallback(callback: @escaping ([FunctionCall]) -> Void){
+    open func registerCallback(callback: @escaping ([FunctionCall]) -> Void) {
         callbacks.append(callback)
     }
 
-    open func callCallbacks(calls: [FunctionCall]){
-        for callback in callbacks{
+    open func callCallbacks(calls: [FunctionCall]) {
+        for callback in callbacks {
             callback(calls)
         }
     }

--- a/Tests/Mocks.swift
+++ b/Tests/Mocks.swift
@@ -221,8 +221,8 @@ open class MockWebSocket: WebSocket {
 
 public func stringContainsElements(_ str: String, elements: [String]) -> Bool {
     var allElementsPresent = true
-    for e in elements {
-        if str.range(of: e) == nil {
+    for element in elements {
+        if str.range(of: element) == nil {
             allElementsPresent = false
         }
     }

--- a/Tests/PresenceChannelTests.swift
+++ b/Tests/PresenceChannelTests.swift
@@ -89,7 +89,7 @@ class PusherPresenceChannelTests: XCTestCase {
         pusher.connect()
         let ex = expectation(description: "member added")
 
-        var chan: PusherPresenceChannel? = nil
+        var chan: PusherPresenceChannel?
         let memberAdded = { (member: PusherPresenceChannelMember) in
             let member = chan!.findMember(userId: "100")
 
@@ -180,7 +180,7 @@ class PusherPresenceChannelTests: XCTestCase {
             ex.fulfill()
         }
         let chan = pusher.subscribe("presence-channel", onMemberAdded: memberAddedFunction) as? PusherPresenceChannel
-        chan?.bind(eventName: "pusher:subscription_succeeded") { (event: PusherEvent) in
+        chan?.bind(eventName: "pusher:subscription_succeeded") { (_: PusherEvent) in
             let jsonDict = """
             {
                 "event": "pusher_internal:member_added",
@@ -204,7 +204,7 @@ class PusherPresenceChannelTests: XCTestCase {
         }
         let chan = pusher.subscribe("presence-channel", onMemberAdded: nil, onMemberRemoved: memberRemovedFunction) as? PusherPresenceChannel
         chan?.members.append(PusherPresenceChannelMember(userId: "100"))
-        chan?.bind(eventName: "pusher:subscription_succeeded") { (event: PusherEvent) in
+        chan?.bind(eventName: "pusher:subscription_succeeded") { (_: PusherEvent) in
             let jsonDict = """
             {
                 "event": "pusher_internal:member_removed",
@@ -227,7 +227,7 @@ class PusherPresenceChannelTests: XCTestCase {
             ex.fulfill()
         }
         let chan = pusher.subscribe("presence-channel", onMemberAdded: nil, onMemberRemoved: memberRemovedFunction) as? PusherPresenceChannel
-        chan?.bind(eventName: "pusher:subscription_succeeded") { (event: PusherEvent) in
+        chan?.bind(eventName: "pusher:subscription_succeeded") { (_: PusherEvent) in
             let addedJsonDict = """
             {
                 "event": "pusher_internal:member_added",

--- a/Tests/PusherChannelTests.swift
+++ b/Tests/PusherChannelTests.swift
@@ -24,15 +24,15 @@ class PusherChannelTests: XCTestCase {
     func testBindingACallbackToAChannelForAGivenEventName() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertEqual(chan.eventHandlers.count, 0, "the channel should have no callbacks")
-        let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
+        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 1, "the channel should have one callback")
     }
 
     func testUnbindingADataCallbackForAGivenEventNameAndCallbackId() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
-        let idOne = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
-        let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
+        let idOne = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
+        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
         chan.unbind(eventName: "test-event", callbackId: idOne)
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 1, "the channel should have one callback for event \"test-event\"")
@@ -41,8 +41,8 @@ class PusherChannelTests: XCTestCase {
     func testUnbindingAnEventCallbackForAGivenEventNameAndCallbackId() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
-        let idOne = chan.bind(eventName: "test-event", eventCallback: { (event: PusherEvent) -> Void in })
-        let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
+        let idOne = chan.bind(eventName: "test-event", eventCallback: { (_: PusherEvent) -> Void in })
+        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
         chan.unbind(eventName: "test-event", callbackId: idOne)
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 1, "the channel should have one callback for event \"test-event\"")
@@ -51,8 +51,8 @@ class PusherChannelTests: XCTestCase {
     func testUnbindingAllCallbacksForAGivenEventName() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
-        let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
-        let _ = chan.bind(eventName: "test-event", eventCallback: { (event: PusherEvent) -> Void in })
+        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
+        _ = chan.bind(eventName: "test-event", eventCallback: { (_: PusherEvent) -> Void in })
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
         chan.unbindAll(forEventName: "test-event")
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 0, "the channel should have no callbacks for event \"test-event\"")
@@ -61,9 +61,9 @@ class PusherChannelTests: XCTestCase {
     func testUnbindingAllCallbacksForAGivenChannel() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertEqual(chan.eventHandlers.count, 0, "the channel should have no callbacks")
-        let _ = chan.bind(eventName: "test-event", callback: { (data: Any?) -> Void in })
-        let _ = chan.bind(eventName: "test-event", eventCallback: { (event: PusherEvent) -> Void in })
-        let _ = chan.bind(eventName: "test-event-3", callback: { (data: Any?) -> Void in })
+        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
+        _ = chan.bind(eventName: "test-event", eventCallback: { (_: PusherEvent) -> Void in })
+        _ = chan.bind(eventName: "test-event-3", callback: { (_: Any?) -> Void in })
         XCTAssertEqual(chan.eventHandlers.count, 2, "the channel should have two event names with callbacks")
         chan.unbindAll()
         XCTAssertEqual(chan.eventHandlers.count, 0, "the channel should have no callbacks")

--- a/Tests/PusherConnectionDelegateTests.swift
+++ b/Tests/PusherConnectionDelegateTests.swift
@@ -52,7 +52,8 @@ class PusherConnectionDelegateTests: XCTestCase {
     var key: String!
     var pusher: Pusher!
     var socket: MockWebSocket!
-    weak var dummyDelegate: DummyDelegate!
+    // swiftlint:disable:next weak_delegate
+    var dummyDelegate: DummyDelegate!
 
     override func setUp() {
         super.setUp()

--- a/Tests/PusherConnectionDelegateTests.swift
+++ b/Tests/PusherConnectionDelegateTests.swift
@@ -9,12 +9,12 @@ import XCTest
 class PusherConnectionDelegateTests: XCTestCase {
     open class DummyDelegate: PusherDelegate {
         public let stubber = StubberForMocks()
-        open var socket: MockWebSocket? = nil
-        open var ex: XCTestExpectation? = nil
-        var testingChannelName: String? = nil
+        open var socket: MockWebSocket?
+        open var ex: XCTestExpectation?
+        var testingChannelName: String?
 
         open func changedConnectionState(from old: ConnectionState, to new: ConnectionState) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "connectionChange",
                 args: [old, new],
                 functionToCall: nil
@@ -40,7 +40,7 @@ class PusherConnectionDelegateTests: XCTestCase {
         }
 
         open func receivedError(error: PusherError) {
-            let _ = stubber.stub(
+            _ = stubber.stub(
                 functionName: "error",
                 args: [error],
                 functionToCall: nil
@@ -52,7 +52,7 @@ class PusherConnectionDelegateTests: XCTestCase {
     var key: String!
     var pusher: Pusher!
     var socket: MockWebSocket!
-    var dummyDelegate: DummyDelegate!
+    weak var dummyDelegate: DummyDelegate!
 
     override func setUp() {
         super.setUp()
@@ -92,7 +92,7 @@ class PusherConnectionDelegateTests: XCTestCase {
                 XCTAssertEqual(calls.last?.args?.last as? ConnectionState, ConnectionState.connected)
                 isConnected.fulfill()
                 self.pusher.disconnect()
-            }else if calls.count == 4 {
+            } else if calls.count == 4 {
                 XCTAssertEqual(calls[2].name, "connectionChange")
                 XCTAssertEqual(calls[2].args?.first as? ConnectionState, ConnectionState.connected)
                 XCTAssertEqual(calls[2].args?.last as? ConnectionState, ConnectionState.disconnecting)
@@ -118,7 +118,7 @@ class PusherConnectionDelegateTests: XCTestCase {
         dummyDelegate.ex = ex
         dummyDelegate.testingChannelName = channelName
 
-        let _ = pusher.subscribe(channelName)
+        _ = pusher.subscribe(channelName)
         pusher.connect()
 
         waitForExpectations(timeout: 0.5)
@@ -131,14 +131,14 @@ class PusherConnectionDelegateTests: XCTestCase {
         dummyDelegate.testingChannelName = channelName
         pusher.connection.options.authMethod = .noMethod
 
-        let _ = pusher.subscribe(channelName)
+        _ = pusher.subscribe(channelName)
         pusher.connect()
 
         waitForExpectations(timeout: 0.5)
     }
 
     func testErrorFunctionCalledWhenPusherErrorIsReceived() {
-        let payload = "{\"event\":\"pusher:error\", \"data\":{\"message\":\"Application is over connection quota\",\"code\":4004}}";
+        let payload = "{\"event\":\"pusher:error\", \"data\":{\"message\":\"Application is over connection quota\",\"code\":4004}}"
         pusher.connection.websocketDidReceiveMessage(socket: socket, text: payload)
 
         XCTAssertEqual(dummyDelegate.stubber.calls.last?.name, "error")

--- a/Tests/PusherConnectionTests.swift
+++ b/Tests/PusherConnectionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-//swiftlint:disable nesting
+// swiftlint:disable nesting
 
 #if WITH_ENCRYPTION
     @testable import PusherSwiftWithEncryption

--- a/Tests/PusherConnectionTests.swift
+++ b/Tests/PusherConnectionTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 
+//swiftlint:disable nesting
+
 #if WITH_ENCRYPTION
     @testable import PusherSwiftWithEncryption
 #else

--- a/Tests/PusherEventFactoryTests.swift
+++ b/Tests/PusherEventFactoryTests.swift
@@ -21,7 +21,7 @@ class PusherEventFactoryTests: XCTestCase {
             "channel": "my-channel",
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -36,7 +36,7 @@ class PusherEventFactoryTests: XCTestCase {
             "channel": "my-channel",
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -51,7 +51,7 @@ class PusherEventFactoryTests: XCTestCase {
             "channel": "my-channel",
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -67,7 +67,7 @@ class PusherEventFactoryTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}",
             "user_id":"user123"
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -82,7 +82,7 @@ class PusherEventFactoryTests: XCTestCase {
             "channel": "my-channel",
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -97,7 +97,7 @@ class PusherEventFactoryTests: XCTestCase {
             "channel": "my-channel",
             "data": "[\\"test\\",\\\"and\\"]"
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -112,7 +112,7 @@ class PusherEventFactoryTests: XCTestCase {
             "channel": "my-channel",
             "data": "test"
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -129,7 +129,7 @@ class PusherEventFactoryTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}",
             "my_property": "string123"
         }
-        """.toJsonDict();
+        """.toJsonDict()
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
         XCTAssertEqual(event.property(withKey: "my_property") as! String, "string123")
     }
@@ -142,7 +142,7 @@ class PusherEventFactoryTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}",
             "my_integer": 1234567
         }
-        """.toJsonDict();
+        """.toJsonDict()
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
         XCTAssertEqual(event.property(withKey: "my_integer") as! Int, 1234567)
@@ -156,7 +156,7 @@ class PusherEventFactoryTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}",
             "my_boolean": true
         }
-        """.toJsonDict();
+        """.toJsonDict()
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
         XCTAssertEqual(event.property(withKey: "my_boolean") as! Bool, true)
@@ -170,7 +170,7 @@ class PusherEventFactoryTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}",
             "my_array": [1, 2, 3]
         }
-        """.toJsonDict();
+        """.toJsonDict()
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
         XCTAssertEqual(event.property(withKey: "my_array") as! [Int], [1, 2, 3])
@@ -184,7 +184,7 @@ class PusherEventFactoryTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}",
             "my_object": {"key": "value"}
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -199,7 +199,7 @@ class PusherEventFactoryTests: XCTestCase {
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}",
             "my_null": null
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         let event = try! eventFactory.makeEvent(fromJSON: jsonDict)
 
@@ -212,7 +212,7 @@ class PusherEventFactoryTests: XCTestCase {
             "channel": "my-channel",
             "data": "{\\"test\\":\\"test string\\",\\"and\\":\\"another\\"}"
         }
-        """.toJsonDict();
+        """.toJsonDict()
 
         XCTAssertThrowsError(try eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: nil)) { (error) in
             XCTAssertEqual(error as? PusherEventError, PusherEventError.invalidFormat)

--- a/Tests/PusherEventQueueTests.swift
+++ b/Tests/PusherEventQueueTests.swift
@@ -33,7 +33,8 @@ class PusherEventQueueTests: XCTestCase {
 
     var eventQueue: PusherEventQueue!
     var eventFactory: PusherEventFactory!
-    weak var eventQueueDelegate: InlineMockEventQueueDelegate!
+    // swiftlint:disable:next weak_delegate
+    var eventQueueDelegate: InlineMockEventQueueDelegate!
     var channels: PusherChannels!
     var connection: PusherConnection!
 

--- a/Tests/PusherEventQueueTests.swift
+++ b/Tests/PusherEventQueueTests.swift
@@ -12,7 +12,7 @@ class InlineMockEventQueueDelegate: PusherEventQueueDelegate {
     var reloadDecryptionKeySync: ((PusherEventQueue, PusherChannel) -> Void)?
     var didReceiveInvalidEvent: ((PusherEventQueue, PusherEventPayload) -> Void)?
 
-    func eventQueue(_ eventQueue: PusherEventQueue, didReceiveInvalidEventWithPayload payload: PusherEventPayload){
+    func eventQueue(_ eventQueue: PusherEventQueue, didReceiveInvalidEventWithPayload payload: PusherEventPayload) {
         self.didReceiveInvalidEvent?(eventQueue, payload)
     }
 
@@ -33,10 +33,9 @@ class PusherEventQueueTests: XCTestCase {
 
     var eventQueue: PusherEventQueue!
     var eventFactory: PusherEventFactory!
-    var eventQueueDelegate: InlineMockEventQueueDelegate!
+    weak var eventQueueDelegate: InlineMockEventQueueDelegate!
     var channels: PusherChannels!
     var connection: PusherConnection!
-
 
     override func setUp() {
         super.setUp()

--- a/Tests/PusherIncomingEventHandlingTests.swift
+++ b/Tests/PusherIncomingEventHandlingTests.swift
@@ -23,8 +23,8 @@ class HandlingIncomingEventsTests: XCTestCase {
 
     func testCallbacksOnGlobalChannelShouldBeCalled() {
         let ex = expectation(description: "Callback should be called")
-        let _ = pusher.subscribe(channelName: "my-channel")
-        let _ = pusher.bind { (data: Any?) -> Void in
+        _ = pusher.subscribe(channelName: "my-channel")
+        _ = pusher.bind { (_: Any?) -> Void in
             ex.fulfill()
         }
 
@@ -43,7 +43,7 @@ class HandlingIncomingEventsTests: XCTestCase {
     func testCallbacksOnRelevantChannelsShouldBeCalled() {
         let ex = expectation(description: "Callback should be called")
         let chan = pusher.subscribe("my-channel")
-        let _ = chan.bind(eventName: "test-event") { (data: Any?) -> Void in
+        _ = chan.bind(eventName: "test-event") { (_: Any?) -> Void in
             ex.fulfill()
         }
 
@@ -64,10 +64,10 @@ class HandlingIncomingEventsTests: XCTestCase {
         let channelEx = expectation(description: "Channel callback should be called")
 
         let callback = { (data: Any?) -> Void in globalEx.fulfill() }
-        let _ = pusher.bind(callback)
+        _ = pusher.bind(callback)
         let chan = pusher.subscribe("my-channel")
         let callbackForChannel = { (data: Any?) -> Void in channelEx.fulfill() }
-        let _ = chan.bind(eventName: "test-event", callback: callbackForChannel)
+        _ = chan.bind(eventName: "test-event", callback: callbackForChannel)
 
         let jsonDict = """
         {
@@ -87,8 +87,8 @@ class HandlingIncomingEventsTests: XCTestCase {
             XCTAssertEqual(data as! [String: String], ["event": "test-event", "channel": "my-channel", "data": "{\"test\":\"test string\",\"and\":\"another\"}"])
             ex.fulfill()
         }
-        let _ = pusher.subscribe("my-channel")
-        let _ = pusher.bind(callback)
+        _ = pusher.subscribe("my-channel")
+        _ = pusher.bind(callback)
 
         let jsonDict = """
         {
@@ -114,8 +114,8 @@ class HandlingIncomingEventsTests: XCTestCase {
             XCTAssertEqual(data as! [String: String], ["event": "test-event", "data": "{\"test\":\"test string\",\"and\":\"another\"}"])
             ex.fulfill()
         }
-        let _ = pusher.subscribe("my-channel")
-        let _ = pusher.bind(callback)
+        _ = pusher.subscribe("my-channel")
+        _ = pusher.bind(callback)
 
         let jsonDict = """
         {
@@ -147,7 +147,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             XCTAssertEqual(data, ["code": "<null>", "message": "Existing subscription to channel my-channel"] as [String: String])
             ex.fulfill()
         }
-        let _ = pusher.bind(callback)
+        _ = pusher.bind(callback)
 
         let jsonDict = """
         {
@@ -170,7 +170,7 @@ class HandlingIncomingEventsTests: XCTestCase {
         }
 
         let chan = pusher.subscribe("my-channel")
-        let _ = chan.bind(eventName: "test-event", callback: callback)
+        _ = chan.bind(eventName: "test-event", callback: callback)
 
         let jsonDict = """
         {
@@ -193,7 +193,7 @@ class HandlingIncomingEventsTests: XCTestCase {
         }
 
         let chan = pusher.subscribe("my-channel")
-        let _ = chan.bind(eventName: "test-event", callback: callback)
+        _ = chan.bind(eventName: "test-event", callback: callback)
 
         let jsonDict = """
         {
@@ -219,7 +219,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             ex.fulfill()
         }
         let chan = pusher.subscribe("my-channel")
-        let _ = chan.bind(eventName: "test-event", callback: callback)
+        _ = chan.bind(eventName: "test-event", callback: callback)
 
         let jsonDict = """
         {
@@ -236,7 +236,7 @@ class HandlingIncomingEventsTests: XCTestCase {
     func testReceivingAnErrorWhereTheDataPartOfTheMessageIsNotDoubleEncodedViaDataCallback() {
         let ex = expectation(description: "Callback should be called")
 
-        let _ = pusher.bind({ (message: Any?) in
+        _ = pusher.bind({ (message: Any?) in
             if let message = message as? [String: AnyObject], let eventName = message["event"] as? String, eventName == "pusher:error" {
                 if let data = message["data"] as? [String: AnyObject], let errorMessage = data["message"] as? String {
                     XCTAssertEqual(errorMessage, "Existing subscription to channel my-channel")
@@ -246,7 +246,7 @@ class HandlingIncomingEventsTests: XCTestCase {
         })
         // pretend that we tried to subscribe to my-channel twice and got this error
         // back from Pusher
-        let payload = "{\"event\":\"pusher:error\", \"data\":{\"message\":\"Existing subscription to channel my-channel\"}}";
+        let payload = "{\"event\":\"pusher:error\", \"data\":{\"message\":\"Existing subscription to channel my-channel\"}}"
         pusher.connection.websocketDidReceiveMessage(socket: socket, text: payload)
 
         waitForExpectations(timeout: 0.5)
@@ -271,7 +271,7 @@ class HandlingIncomingEventsTests: XCTestCase {
             ex.fulfill()
         }
         let chan = pusher.subscribe("my-channel")
-        let _ = chan.bind(eventName: "test-event", eventCallback: callback)
+        _ = chan.bind(eventName: "test-event", eventCallback: callback)
 
         let jsonDict = """
         {
@@ -303,8 +303,8 @@ class HandlingIncomingEventsTests: XCTestCase {
 
             ex.fulfill()
         }
-        let _ = pusher.subscribe("my-channel")
-        let _ = pusher.bind(eventCallback: callback)
+        _ = pusher.subscribe("my-channel")
+        _ = pusher.bind(eventCallback: callback)
 
         XCTAssertNil(socket.eventGivenToCallback)
          let jsonDict = """

--- a/Tests/PusherSwift-Only/PusherEventFactory+DecryptionTests.swift
+++ b/Tests/PusherSwift-Only/PusherEventFactory+DecryptionTests.swift
@@ -14,16 +14,16 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
     }
 
     // MARK: Encryption related tests
-    
+
     func test_init_unencryptedChannelAndUnencryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "test": "test string",
             "and": "another"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "test-event",
@@ -39,18 +39,18 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(event.channelName, "my-channel")
             XCTAssertEqual(event.data, dataPayload)
         }
-        
+
     }
-    
+
     func test_init_unencryptedChannelAndEncryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "test-event",
@@ -58,7 +58,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict)
 
         XCTAssertNotNil(event) { event in
@@ -66,18 +66,18 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(event.channelName, "my-channel")
             XCTAssertEqual(event.data, dataPayload)
         }
-        
+
     }
-    
+
     func test_init_encryptedChannelAndPusherEventAndUnencryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "test": "test string",
             "and": "another"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "pusher:event",
@@ -85,7 +85,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict)
 
         XCTAssertNotNil(event) { event in
@@ -94,17 +94,16 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(event.data, dataPayload)
         }
     }
-    
-    
+
     func test_init_encryptedChannelAndPusherEventAndEncryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "pusher:event",
@@ -112,7 +111,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict)
 
         XCTAssertNotNil(event) { event in
@@ -121,16 +120,16 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(event.data, dataPayload)
         }
     }
-    
+
     func test_init_encryptedChannelAndUserEventAndUnencryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "test": "test string",
             "and": "another"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -138,7 +137,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict)
 
         XCTAssertNotNil(event) { event in
@@ -147,7 +146,6 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(event.data, dataPayload)
         }
     }
-
 
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadAndValidKey_returnsWithUnalteredPayload() {
 
@@ -159,7 +157,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -177,19 +175,17 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
         }
     }
 
-    
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadKey_returnsWithUnalteredPayload() {
-        
+
         let decryptionKey = "00000000000000000000000000000000000000000000"
 
-        
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -197,7 +193,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: decryptionKey)
 
         XCTAssertNotNil(event) { event in
@@ -206,7 +202,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(event.data, dataPayload)
         }
     }
-    
+
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadNonce_returnsWithUnalteredPayload() {
 
         let decryptionKey = "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs="
@@ -217,7 +213,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -225,7 +221,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: decryptionKey)
 
         XCTAssertNotNil(event) { event in
@@ -234,18 +230,18 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(event.data, dataPayload)
         }
     }
-    
+
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadCiphertext_returnsWithUnalteredPayload() {
-        
+
         let decryptionKey = "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs="
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "00000000000000000000000000000000000000000000000000000000000000000000"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -253,7 +249,7 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: decryptionKey)
 
         XCTAssertNotNil(event) { event in

--- a/Tests/PusherSwift-Only/PusherEventQueue+DecryptionTests.swift
+++ b/Tests/PusherSwift-Only/PusherEventQueue+DecryptionTests.swift
@@ -6,7 +6,8 @@ class PusherEventQueueDecryptionTests: XCTestCase {
     var eventQueue: PusherEventQueue!
     var channels: PusherChannels!
     var eventFactory: PusherEventFactory!
-    weak var eventQueueDelegate: InlineMockEventQueueDelegate!
+    // swiftlint:disable:next weak_delegate
+    var eventQueueDelegate: InlineMockEventQueueDelegate!
     var mockConnection: PusherConnection!
 
     override func setUp() {

--- a/Tests/PusherSwift-Only/PusherEventQueue+DecryptionTests.swift
+++ b/Tests/PusherSwift-Only/PusherEventQueue+DecryptionTests.swift
@@ -6,9 +6,8 @@ class PusherEventQueueDecryptionTests: XCTestCase {
     var eventQueue: PusherEventQueue!
     var channels: PusherChannels!
     var eventFactory: PusherEventFactory!
-    var eventQueueDelegate: InlineMockEventQueueDelegate!
+    weak var eventQueueDelegate: InlineMockEventQueueDelegate!
     var mockConnection: PusherConnection!
-
 
     override func setUp() {
         super.setUp()
@@ -42,7 +41,6 @@ class PusherEventQueueDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-
 
         let ex = expectation(description: "should call didReceiveEvent")
         eventQueueDelegate.didReceiveEvent = { (eventQueue, event, channelName) in

--- a/Tests/PusherSwiftWithEncryption-Only/PusherEventFactory+DecryptionTests.swift
+++ b/Tests/PusherSwiftWithEncryption-Only/PusherEventFactory+DecryptionTests.swift
@@ -8,18 +8,18 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
     override func setUp() {
         eventFactory = PusherConcreteEventFactory()
     }
-    
+
     // MARK: Encryption related tests
-    
+
     func test_init_unencryptedChannelAndUnencryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "test": "test string",
             "and": "another"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "test-event",
@@ -27,26 +27,26 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict)
-        
+
         XCTAssertNotNil(event) { event in
             XCTAssertEqual(event.eventName, "test-event")
             XCTAssertEqual(event.channelName, "my-channel")
             XCTAssertEqual(event.data, dataPayload)
         }
-        
+
     }
-    
+
     func test_init_unencryptedChannelAndEncryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "test-event",
@@ -54,26 +54,26 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict)
-        
+
         XCTAssertNotNil(event) { event in
             XCTAssertEqual(event.eventName, "test-event")
             XCTAssertEqual(event.channelName, "my-channel")
             XCTAssertEqual(event.data, dataPayload)
         }
-        
+
     }
-    
+
     func test_init_encryptedChannelAndPusherEventAndUnencryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "test": "test string",
             "and": "another"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "pusher:event",
@@ -81,26 +81,25 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict)
-        
+
         XCTAssertNotNil(event) { event in
             XCTAssertEqual(event.eventName, "pusher:event")
             XCTAssertEqual(event.channelName, "private-encrypted-channel")
             XCTAssertEqual(event.data, dataPayload)
         }
     }
-    
-    
+
     func test_init_encryptedChannelAndPusherEventAndEncryptedPayload_returnsWithUnalteredPayload() {
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "pusher:event",
@@ -108,25 +107,25 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
        let event = try? eventFactory.makeEvent(fromJSON: jsonDict)
-        
+
         XCTAssertNotNil(event) { event in
             XCTAssertEqual(event.eventName, "pusher:event")
             XCTAssertEqual(event.channelName, "private-encrypted-channel")
             XCTAssertEqual(event.data, dataPayload)
         }
     }
-    
+
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadWithNoDecryptionKey_throwsInvalidDecryptionKey() {
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -228,18 +227,18 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(error as? PusherEventError, PusherEventError.invalidEncryptedData)
         }
     }
-    
+
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadAndValidKey_returnsWithDecryptedPayload() {
-        
+
         let decryptionKey = "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs="
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -247,34 +246,34 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             "data": \(dataPayload.escaped)
         }
         """.toJsonDict()
-        
+
         let event = try? eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: decryptionKey)
-        
+
         let expectedDecryptedPayload = """
         {
             "name": "freddy",
             "message": "hello"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         XCTAssertNotNil(event) { event in
             XCTAssertEqual(event.eventName, "user-event")
             XCTAssertEqual(event.channelName, "private-encrypted-channel")
             XCTAssertEqual(event.data, expectedDecryptedPayload)
         }
     }
-    
+
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadKey_throwsInvalidDecryptionKey() {
-        
+
         let decryptionKey = "00000000000000000000000000000000000000000000"
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -283,23 +282,22 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
         }
         """.toJsonDict()
 
-
         XCTAssertThrowsError(try eventFactory.makeEvent(fromJSON: jsonDict, withDecryptionKey: decryptionKey)) { (error) in
             XCTAssertEqual(error as? PusherEventError, PusherEventError.invalidDecryptionKey)
         }
     }
-    
+
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadNonce_throwsInvalidDecryptionKey() {
-        
+
         let decryptionKey = "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs="
-        
+
         let dataPayload = """
         {
             "nonce": "00000000000000000000000000000000",
             "ciphertext": "ig9HfL7OKJ9TL97WFRG0xpuk9w0DXUJhLQlQbGf+ID9S3h15vb/fgDfsnsGxQNQDxw+i"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",
@@ -312,18 +310,18 @@ class PusherEventFactoryDecryptionTests: XCTestCase {
             XCTAssertEqual(error as? PusherEventError, PusherEventError.invalidDecryptionKey)
         }
     }
-    
+
     func test_init_encryptedChannelAndUserEventAndEncryptedPayloadButBadCiphertext_throwsInvalidDecryptionKey() {
-        
+
         let decryptionKey = "EOWC/ked3NtBDvEs9gFwk7x4oZEbH9I0Lz2qkopBxxs="
-        
+
         let dataPayload = """
         {
             "nonce": "Ew2lLeGzSefk8fyVPbwL1yV+8HMyIBrm",
             "ciphertext": "00000000000000000000000000000000000000000000000000000000000000000000"
         }
         """.removing(.whitespacesAndNewlines)
-        
+
         let jsonDict = """
         {
             "event": "user-event",

--- a/Tests/PusherSwiftWithEncryption-Only/PusherEventQueue+DecryptionTests.swift
+++ b/Tests/PusherSwiftWithEncryption-Only/PusherEventQueue+DecryptionTests.swift
@@ -6,7 +6,7 @@ class PusherEventQueueDecryptionTests: XCTestCase {
     var eventQueue: PusherEventQueue!
     var channels: PusherChannels!
     var eventFactory: PusherEventFactory!
-    var eventQueueDelegate: InlineMockEventQueueDelegate!
+    weak var eventQueueDelegate: InlineMockEventQueueDelegate!
     var mockConnection: PusherConnection!
 
     override func setUp() {
@@ -339,5 +339,4 @@ class PusherEventQueueDecryptionTests: XCTestCase {
         waitForExpectations(timeout: 0.5)
     }
 
-    
 }

--- a/Tests/PusherSwiftWithEncryption-Only/PusherEventQueue+DecryptionTests.swift
+++ b/Tests/PusherSwiftWithEncryption-Only/PusherEventQueue+DecryptionTests.swift
@@ -6,7 +6,8 @@ class PusherEventQueueDecryptionTests: XCTestCase {
     var eventQueue: PusherEventQueue!
     var channels: PusherChannels!
     var eventFactory: PusherEventFactory!
-    weak var eventQueueDelegate: InlineMockEventQueueDelegate!
+    // swiftlint:disable:next weak_delegate
+    var eventQueueDelegate: InlineMockEventQueueDelegate!
     var mockConnection: PusherConnection!
 
     override func setUp() {

--- a/Tests/PusherTopLevelAPITests.swift
+++ b/Tests/PusherTopLevelAPITests.swift
@@ -11,7 +11,7 @@ class PusherTopLevelApiTests: XCTestCase {
     class ConnectionStateDelegate: PusherDelegate {
         var callbacks: [ConnectionState: [() -> Void]] = [:]
 
-        func registerCallback(connectionState: ConnectionState, callback: @escaping () -> Void){
+        func registerCallback(connectionState: ConnectionState, callback: @escaping () -> Void) {
             var connectionStateCallbacks = callbacks[connectionState, default: []]
             connectionStateCallbacks.append(callback)
             callbacks[connectionState] = connectionStateCallbacks
@@ -27,8 +27,8 @@ class PusherTopLevelApiTests: XCTestCase {
     }
 
     class DummyDelegate: PusherDelegate {
-        var ex: XCTestExpectation? = nil
-        var testingChannelName: String? = nil
+        var ex: XCTestExpectation?
+        var testingChannelName: String?
         var connectionStubber = StubberForMocks()
 
         func subscribedToChannel(name: String) {
@@ -38,7 +38,7 @@ class PusherTopLevelApiTests: XCTestCase {
         }
 
         func changedConnectionState(from old: ConnectionState, to new: ConnectionState) {
-            let _ = connectionStubber.stub(
+            _ = connectionStubber.stub(
                 functionName: "connectionChange",
                 args: [old, new],
                 functionToCall: nil
@@ -111,13 +111,13 @@ class PusherTopLevelApiTests: XCTestCase {
         let connected = expectation(description: "should connect")
         let disconnected = expectation(description: "should disconnect")
 
-        delegate.registerCallback(connectionState: ConnectionState.connected){
+        delegate.registerCallback(connectionState: ConnectionState.connected) {
             XCTAssertEqual(self.pusher.connection.connectionState, ConnectionState.connected)
             connected.fulfill()
             self.pusher.disconnect()
         }
 
-        delegate.registerCallback(connectionState: ConnectionState.disconnected){
+        delegate.registerCallback(connectionState: ConnectionState.disconnected) {
             XCTAssertEqual(self.pusher.connection.connectionState, ConnectionState.disconnected)
             disconnected.fulfill()
         }
@@ -134,7 +134,7 @@ class PusherTopLevelApiTests: XCTestCase {
         let disconnected = expectation(description: "should disconnect")
 
         let chan = pusher.subscribe("test-channel")
-        connectionDelegate.registerCallback(connectionState: ConnectionState.disconnected){
+        connectionDelegate.registerCallback(connectionState: ConnectionState.disconnected) {
             XCTAssertFalse(chan.subscribed)
             disconnected.fulfill()
         }
@@ -167,9 +167,9 @@ class PusherTopLevelApiTests: XCTestCase {
         let connected = expectation(description: "should connect")
         let subscribed = expectation(description: "should subscribe")
 
-        delegate.registerCallback(connectionState: ConnectionState.connected){
+        delegate.registerCallback(connectionState: ConnectionState.connected) {
             connected.fulfill()
-            let _ = self.pusher.subscribe("test-channel")
+            _ = self.pusher.subscribe("test-channel")
 
             self.socket.stubber.registerCallback { calls in
                 if let name = calls.last?.name, name == "writeString" {
@@ -207,8 +207,8 @@ class PusherTopLevelApiTests: XCTestCase {
                 ex.fulfill()
             }
         }
-        let _ = pusher.bind(callback)
-        let _ = pusher.subscribe("test-channel")
+        _ = pusher.bind(callback)
+        _ = pusher.subscribe("test-channel")
         waitForExpectations(timeout: 0.5)
     }
 
@@ -218,7 +218,7 @@ class PusherTopLevelApiTests: XCTestCase {
             ex.fulfill()
         }
         let channel = pusher.subscribe("test-channel")
-        let _ = channel.bind(eventName: "pusher:subscription_succeeded", callback: callback)
+        _ = channel.bind(eventName: "pusher:subscription_succeeded", callback: callback)
         pusher.connect()
         waitForExpectations(timeout: 0.5)
     }
@@ -231,8 +231,8 @@ class PusherTopLevelApiTests: XCTestCase {
                 ex.fulfill()
             }
         }
-        let _ = pusher.bind(eventCallback: callback)
-        let _ = pusher.subscribe("test-channel")
+        _ = pusher.bind(eventCallback: callback)
+        _ = pusher.subscribe("test-channel")
         waitForExpectations(timeout: 0.5)
     }
 
@@ -242,7 +242,7 @@ class PusherTopLevelApiTests: XCTestCase {
             ex.fulfill()
         }
         let channel = pusher.subscribe("test-channel")
-        let _ = channel.bind(eventName: "pusher:subscription_succeeded", eventCallback: callback)
+        _ = channel.bind(eventName: "pusher:subscription_succeeded", eventCallback: callback)
         pusher.connect()
         waitForExpectations(timeout: 0.5)
     }
@@ -266,7 +266,7 @@ class PusherTopLevelApiTests: XCTestCase {
         pusher.delegate = dummyDelegate
 
         pusher.connect()
-        let _ = pusher.subscribe(channelName)
+        _ = pusher.subscribe(channelName)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -281,7 +281,7 @@ class PusherTopLevelApiTests: XCTestCase {
         pusher.delegate = dummyDelegate
 
         pusher.connect()
-        let _ = pusher.subscribe(channelName)
+        _ = pusher.subscribe(channelName)
 
         waitForExpectations(timeout: 0.5)
     }
@@ -297,7 +297,7 @@ class PusherTopLevelApiTests: XCTestCase {
 
     func testSubscribingToAPublicChannelWhenCurrentlyDisconnected() {
         let subscribed = expectation(description: "should subscribe")
-        let _ = pusher.subscribe("test-channel")
+        _ = pusher.subscribe("test-channel")
         let testChannel = pusher.connection.channels.channels["test-channel"]
         testChannel!.bind(eventName: "pusher:subscription_succeeded") { (_: PusherEvent) in
             XCTAssertTrue(testChannel!.subscribed)
@@ -326,7 +326,7 @@ class PusherTopLevelApiTests: XCTestCase {
         dummyDelegate.testingChannelName = channelName
         pusher.connection.delegate = dummyDelegate
 
-        let _ = pusher.subscribe(channelName)
+        _ = pusher.subscribe(channelName)
         pusher.connect()
 
         waitForExpectations(timeout: 0.5)
@@ -341,7 +341,7 @@ class PusherTopLevelApiTests: XCTestCase {
         dummyDelegate.testingChannelName = channelName
         pusher.connection.delegate = dummyDelegate
 
-        let _ = pusher.subscribe(channelName)
+        _ = pusher.subscribe(channelName)
         pusher.connect()
 
         waitForExpectations(timeout: 0.5)
@@ -424,7 +424,7 @@ class PusherTopLevelApiTests: XCTestCase {
                         }
                         return NSDictionary(dictionary: parsedCallArgs).isEqual(to: NSDictionary(dictionary: expectedCallArguments) as [NSObject: AnyObject])
                     }
-                    if unsubscribedFromChannel{
+                    if unsubscribedFromChannel {
                         unsubscribeCount += 1
                     }
                 }
@@ -446,7 +446,7 @@ class PusherTopLevelApiTests: XCTestCase {
         let callback = { (data: Any?) in }
 
         XCTAssertEqual(pusher.connection.globalChannel?.globalLegacyCallbacks.count, 0, "the global channel should not have any bound callbacks")
-        let _ = pusher.bind(callback)
+        _ = pusher.bind(callback)
         XCTAssertEqual(pusher.connection.globalChannel?.globalLegacyCallbacks.count, 1, "the global channel should have 1 bound callback")
     }
 
@@ -455,7 +455,7 @@ class PusherTopLevelApiTests: XCTestCase {
         let callback = { (data: PusherEvent?) in }
 
         XCTAssertEqual(pusher.connection.globalChannel?.globalCallbacks.count, 0, "the global channel should not have any bound callbacks")
-        let _ = pusher.bind(eventCallback: callback)
+        _ = pusher.bind(eventCallback: callback)
         XCTAssertEqual(pusher.connection.globalChannel?.globalCallbacks.count, 1, "the global channel should have 1 bound callback")
     }
 
@@ -482,9 +482,9 @@ class PusherTopLevelApiTests: XCTestCase {
     func testUnbindingAllGlobalCallbacksShouldRemoveAllLegacyCallbacksFromGlobalChannel() {
         pusher.connect()
         let callback = { (data: Any?) in }
-        let _ = pusher.bind(callback)
+        _ = pusher.bind(callback)
         let callbackTwo = { (someData: Any?) in }
-        let _ = pusher.bind(callbackTwo)
+        _ = pusher.bind(callbackTwo)
 
         XCTAssertEqual(pusher.connection.globalChannel?.globalLegacyCallbacks.count, 2, "the global channel should have 2 bound callbacks")
         pusher.unbindAll()
@@ -494,9 +494,9 @@ class PusherTopLevelApiTests: XCTestCase {
     func testUnbindingAllGlobalCallbacksShouldRemoveAllCallbacksFromGlobalChannel() {
         pusher.connect()
         let callback = { (data: Any?) in }
-        let _ = pusher.bind(callback)
+        _ = pusher.bind(callback)
         let callbackTwo = { (someData: PusherEvent?) in }
-        let _ = pusher.bind(eventCallback: callbackTwo)
+        _ = pusher.bind(eventCallback: callbackTwo)
 
         XCTAssertEqual(pusher.connection.globalChannel?.globalLegacyCallbacks.count, 1, "the global channel should have 1 bound legacy callback")
         XCTAssertEqual(pusher.connection.globalChannel?.globalCallbacks.count, 1, "the global channel should have 1 bound regular callback")

--- a/Tests/String+Extensions.swift
+++ b/Tests/String+Extensions.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 extension String {
-    
+
     public func removing(_ set: CharacterSet) -> String {
         var newString = self
         newString.removeAll { char -> Bool in
@@ -10,11 +10,11 @@ extension String {
         }
         return newString
     }
-    
+
     public var escaped: String {
         return self.debugDescription
     }
-    
+
     public func toJsonData(validate: Bool = true, file: StaticString = #file, line: UInt = #line) -> Data {
         do {
             let data = try self.toData()
@@ -28,7 +28,7 @@ extension String {
         }
         return Data()
     }
-    
+
     public func toJsonDict(file: StaticString = #file, line: UInt = #line) -> [String: Any] {
         do {
             let json = try toJsonAny()
@@ -38,26 +38,26 @@ extension String {
                 return [:]
             }
             return jsonDict
-            
+
         } catch {
             XCTFail("\(error)", file: file, line: line)
         }
         return [:]
     }
-    
+
     // MARK: - Private methods
-    
+
     private func toJsonAny() throws -> Any {
-        return try JSONSerialization.jsonObject(with: self.toData(), options : .allowFragments)
+        return try JSONSerialization.jsonObject(with: self.toData(), options: .allowFragments)
     }
-    
+
     private func toData() throws -> Data {
         guard let data = self.data(using: .utf8) else {
             throw JSONError.conversionFailed
         }
         return data
     }
-    
+
 }
 
 // MARK: - Error handling

--- a/Tests/XCTest+Assertions.swift
+++ b/Tests/XCTest+Assertions.swift
@@ -9,12 +9,12 @@ private func executeAndAssignEquatableResult<T>(_ expression: @autoclosure () th
 }
 
 public func XCTAssertNotNil<T>(_ expression: @autoclosure () throws -> T?, _ message: String = "", file: StaticString = #file, line: UInt = #line, also validateResult: (T) -> Void) {
-    
+
     var result: T?
-    
+
     XCTAssertNoThrow(try executeAndAssignResult(expression, to: &result), message, file: file, line: line)
     XCTAssertNotNil(result, message, file: file, line: line)
-    
+
     if let result = result {
         validateResult(result)
     }

--- a/iOS Example Swift/.swiftlint.yml
+++ b/iOS Example Swift/.swiftlint.yml
@@ -1,0 +1,2 @@
+disabled_rules:
+  - line_length

--- a/iOS Example Swift/iOS Example Swift/AppDelegate.swift
+++ b/iOS Example Swift/iOS Example Swift/AppDelegate.swift
@@ -10,7 +10,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
 
         return true
     }

--- a/iOS Example Swift/iOS Example Swift/ViewController.swift
+++ b/iOS Example Swift/iOS Example Swift/ViewController.swift
@@ -39,7 +39,7 @@ class ViewController: UIViewController, PusherDelegate {
         pusher.connect()
 
         // bind to all events globally
-        let _ = pusher.bind(eventCallback: { (event: PusherEvent) in
+        _ = pusher.bind(eventCallback: { (event: PusherEvent) in
             var message = "Received event: '\(event.eventName)'"
 
             if let channel = event.channelName {
@@ -59,7 +59,7 @@ class ViewController: UIViewController, PusherDelegate {
         let myChannel = pusher.subscribe("my-channel")
 
         // bind a callback to event "my-event" on that channel
-        let _ = myChannel.bind(eventName: "my-event", eventCallback: { (event: PusherEvent) in
+        _ = myChannel.bind(eventName: "my-event", eventCallback: { (event: PusherEvent) in
 
             // convert the data string to type data for decoding
             guard let json: String = event.data,
@@ -114,7 +114,6 @@ class ViewController: UIViewController, PusherDelegate {
         }
     }
 }
-
 
 class AuthRequestBuilder: AuthRequestBuilderProtocol {
     func requestFor(socketID: String, channelName: String) -> URLRequest? {


### PR DESCRIPTION
This PR resolves #281 

- Adds [SwiftLint](https://github.com/realm/SwiftLint) support
  - Adds `.swiftlint.yml` files to the repository root, as well as [nested configurations ](https://github.com/realm/SwiftLint#nested-configurations) for the `Tests` and `Consumption-Tests` directories.
  - Adds build phases to the build targets for running `swiftlint autocorrect` (for autocorrectable linter rules) followed by running SwiftLint itself.
  - Resolves all of the linter errors and the majority of the linter warnings.

**NOTES:**
- Some linter warnings remain, and these can be addressed separately during further refactoring of the codebase. (see: #287 )
- The Bitrise CI workflows have been modified to introduce a SwiftLint step which will read the included `.swiftlint.yml` file when the CI pipeline is run.
