### PR TITLE
Respect Pusher Channels Protocol WebSocket closure codes

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,4 +13,4 @@ identifier_name:
 
 # This generates a compiler error if more than this many SwiftLint warnings are present
 # (This threshold can become more restrictive as remaining warnings are resolved via refactoring)
-warning_threshold: 22
+warning_threshold: 21

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -32,12 +32,12 @@
 		33C40CB91C1DFC9C008A54E3 /* PusherSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 33831CD61A9CFFF200B124F1 /* PusherSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		53140355250A8F7600F3D7BF /* PusherChannelsProtocolCloseCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53140354250A8F7600F3D7BF /* PusherChannelsProtocolCloseCode.swift */; };
 		53140356250A8F7600F3D7BF /* PusherChannelsProtocolCloseCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53140354250A8F7600F3D7BF /* PusherChannelsProtocolCloseCode.swift */; };
+		53140358250B8A9F00F3D7BF /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53140357250B8A9F00F3D7BF /* WebSocket.swift */; };
+		53140359250B8A9F00F3D7BF /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53140357250B8A9F00F3D7BF /* WebSocket.swift */; };
 		539D9AFC2507F67300B5765A /* PusherLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9AFB2507F67300B5765A /* PusherLogger.swift */; };
 		539D9AFE2507F68400B5765A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9AFD2507F68400B5765A /* Constants.swift */; };
 		539D9AFF2507F69400B5765A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9AFD2507F68400B5765A /* Constants.swift */; };
 		539D9B002507F69B00B5765A /* PusherLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9AFB2507F67300B5765A /* PusherLogger.swift */; };
-		539D9B022509101E00B5765A /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9B012509101E00B5765A /* WebSocket.swift */; };
-		539D9B032509101E00B5765A /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9B012509101E00B5765A /* WebSocket.swift */; };
 		539D9B05250913B300B5765A /* WebSocketConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9B04250913B300B5765A /* WebSocketConnection.swift */; };
 		539D9B06250913B300B5765A /* WebSocketConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9B04250913B300B5765A /* WebSocketConnection.swift */; };
 		736E53F5242A378B0052CC1B /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736E53F3242A35D90052CC1B /* String+Extensions.swift */; };
@@ -146,9 +146,9 @@
 		33BB99671D21226C00B25C2A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = ../Tests/Info.plist; sourceTree = "<group>"; };
 		33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveC.swift; sourceTree = "<group>"; };
 		53140354250A8F7600F3D7BF /* PusherChannelsProtocolCloseCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherChannelsProtocolCloseCode.swift; sourceTree = "<group>"; };
+		53140357250B8A9F00F3D7BF /* WebSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
 		539D9AFB2507F67300B5765A /* PusherLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PusherLogger.swift; sourceTree = "<group>"; };
 		539D9AFD2507F68400B5765A /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		539D9B012509101E00B5765A /* WebSocket.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
 		539D9B04250913B300B5765A /* WebSocketConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketConnection.swift; sourceTree = "<group>"; };
 		736E53F3242A35D90052CC1B /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		736E53F6242A45AC0052CC1B /* XCTest+Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Assertions.swift"; sourceTree = "<group>"; };
@@ -289,7 +289,7 @@
 				E2B21F06243F5B860049A35B /* PusherEvent.swift */,
 				3389F5751CAEDE2800563F49 /* PusherGlobalChannel.swift */,
 				3389F56D1CAEDDD800563F49 /* PusherPresenceChannel.swift */,
-				539D9B012509101E00B5765A /* WebSocket.swift */,
+				53140357250B8A9F00F3D7BF /* WebSocket.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -765,7 +765,6 @@
 				3389F5721CAEDDF300563F49 /* PusherChannels.swift in Sources */,
 				E2CFE43122D79CA7004187C3 /* PusherParser.swift in Sources */,
 				3389F5761CAEDE2800563F49 /* PusherGlobalChannel.swift in Sources */,
-				539D9B022509101E00B5765A /* WebSocket.swift in Sources */,
 				E2B21F01243F5B1E0049A35B /* PusherEventFactory.swift in Sources */,
 				3389F57A1CAEDEC800563F49 /* PusherClientOptions.swift in Sources */,
 				E2B21F07243F5B860049A35B /* PusherEvent.swift in Sources */,
@@ -774,6 +773,7 @@
 				3389F56E1CAEDDD800563F49 /* PusherPresenceChannel.swift in Sources */,
 				33C1FD6F1D81BFC300921AD7 /* ObjectiveC.swift in Sources */,
 				3390D1E61F054D0400E1944D /* AuthRequestBuilderProtocol.swift in Sources */,
+				53140358250B8A9F00F3D7BF /* WebSocket.swift in Sources */,
 				330D7A6A1CAEDA6C0032FF2C /* PusherSwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -822,7 +822,6 @@
 				73D8A1EE2435E5F3001FDE05 /* PusherChannels.swift in Sources */,
 				73D8A1EF2435E5F3001FDE05 /* PusherParser.swift in Sources */,
 				539D9AFF2507F69400B5765A /* Constants.swift in Sources */,
-				539D9B032509101E00B5765A /* WebSocket.swift in Sources */,
 				73D8A1F02435E5F3001FDE05 /* PusherGlobalChannel.swift in Sources */,
 				E2B21F02243F5B1E0049A35B /* PusherEventFactory.swift in Sources */,
 				73D8A1F12435E5F3001FDE05 /* PusherClientOptions.swift in Sources */,
@@ -831,6 +830,7 @@
 				73D8A1F22435E5F3001FDE05 /* PusherPresenceChannel.swift in Sources */,
 				73D8A1F32435E5F3001FDE05 /* ObjectiveC.swift in Sources */,
 				73D8A1F52435E5F3001FDE05 /* AuthRequestBuilderProtocol.swift in Sources */,
+				53140359250B8A9F00F3D7BF /* WebSocket.swift in Sources */,
 				73D8A1F62435E5F3001FDE05 /* PusherSwift.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		53140356250A8F7600F3D7BF /* PusherChannelsProtocolCloseCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53140354250A8F7600F3D7BF /* PusherChannelsProtocolCloseCode.swift */; };
 		53140358250B8A9F00F3D7BF /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53140357250B8A9F00F3D7BF /* WebSocket.swift */; };
 		53140359250B8A9F00F3D7BF /* WebSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53140357250B8A9F00F3D7BF /* WebSocket.swift */; };
+		536F96B8252C841000D2C2F4 /* WebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536F96B7252C841000D2C2F4 /* WebSocketTests.swift */; };
+		536F96B9252C841000D2C2F4 /* WebSocketTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 536F96B7252C841000D2C2F4 /* WebSocketTests.swift */; };
 		539D9AFC2507F67300B5765A /* PusherLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9AFB2507F67300B5765A /* PusherLogger.swift */; };
 		539D9AFE2507F68400B5765A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9AFD2507F68400B5765A /* Constants.swift */; };
 		539D9AFF2507F69400B5765A /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539D9AFD2507F68400B5765A /* Constants.swift */; };
@@ -147,6 +149,7 @@
 		33C1FD6E1D81BFC300921AD7 /* ObjectiveC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectiveC.swift; sourceTree = "<group>"; };
 		53140354250A8F7600F3D7BF /* PusherChannelsProtocolCloseCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PusherChannelsProtocolCloseCode.swift; sourceTree = "<group>"; };
 		53140357250B8A9F00F3D7BF /* WebSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocket.swift; sourceTree = "<group>"; };
+		536F96B7252C841000D2C2F4 /* WebSocketTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketTests.swift; sourceTree = "<group>"; };
 		539D9AFB2507F67300B5765A /* PusherLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PusherLogger.swift; sourceTree = "<group>"; };
 		539D9AFD2507F68400B5765A /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		539D9B04250913B300B5765A /* WebSocketConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketConnection.swift; sourceTree = "<group>"; };
@@ -405,6 +408,7 @@
 				3342F3BB1D808AC500C0296E /* ClientEventTests.swift */,
 				33BB99611D21226C00B25C2A /* PresenceChannelTests.swift */,
 				33BB99621D21226C00B25C2A /* PusherChannelTests.swift */,
+				536F96B7252C841000D2C2F4 /* WebSocketTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -784,6 +788,7 @@
 			files = (
 				73D8A22F2435F393001FDE05 /* PusherEventFactory+DecryptionTests.swift in Sources */,
 				33BB997A1D21230100B25C2A /* PusherConnectionTests.swift in Sources */,
+				536F96B8252C841000D2C2F4 /* WebSocketTests.swift in Sources */,
 				736E53F5242A378B0052CC1B /* String+Extensions.swift in Sources */,
 				E2F40FA723ED79BC00985C40 /* PusherCryptoTest.swift in Sources */,
 				33BB99791D21230100B25C2A /* PusherClientInitializationTests.swift in Sources */,
@@ -844,6 +849,7 @@
 				73D8A2102435F24E001FDE05 /* String+Extensions.swift in Sources */,
 				73D8A2112435F24E001FDE05 /* PusherCryptoTest.swift in Sources */,
 				D32DBA1B2445BCD60064DA56 /* PrivateEncryptedChannelTests.swift in Sources */,
+				536F96B9252C841000D2C2F4 /* WebSocketTests.swift in Sources */,
 				73D8A2122435F24E001FDE05 /* PusherClientInitializationTests.swift in Sources */,
 				73D8A2132435F24E001FDE05 /* PresenceChannelTests.swift in Sources */,
 				73D8A2142435F24E001FDE05 /* PusherTopLevelAPITests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ There are a number of configuration parameters which can be set for the Pusher c
 
 - `authMethod (AuthMethod)` - the method you would like the client to use to authenticate subscription requests to channels requiring authentication (see below for more details)
 - `useTLS (Bool)` - whether or not you'd like to use TLS encrypted transport or not, default is `true`
-- `autoReconnect (Bool)` - set whether or not you'd like the library to try and autoReconnect upon disconnection
+- `autoReconnect (Bool)` - set whether or not you'd like the library to try and automatically reconnect upon disconnection (where possible). See [Reconnection](#reconnection) for more info
 - `host (PusherHost)` - set a custom value for the host you'd like to connect to, e.g. `PusherHost.host("ws-test.pusher.com")`
 - `port (Int)` - set a custom value for the port that you'd like to connect to
 - `activityTimeout (TimeInterval)` - after this time (in seconds) without any messages received from the server, a ping message will be sent to check if the connection is still working; the default value is supplied by the server, low values will result in unnecessary traffic.
@@ -577,6 +577,8 @@ The library uses [Reachability](https://github.com/ashleymills/Reachability.swif
 If the Pusher servers close the websocket, or if a disconnection happens due to network events that aren't covered by Reachability, then the library will still attempt to reconnect as described above.
 
 All of this is the case if you have the client option of `autoReconnect` set as `true`, which it is by default. If the reconnection strategies are not suitable for your use case then you can set `autoReconnect` to `false` and implement your own reconnection strategy based on the connection state changes.
+
+N.B: If the Pusher servers close the websocket with a [Channels Protocol closure code](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#connection-closure), then the `autoReconnect` option is ignored, and the reconnection strategy is determined by the specific closure code that was received.
 
 There are a couple of properties on the connection (`PusherConnection`) that you can set that affect how the reconnection behaviour works. These are:
 

--- a/Sources/Extensions/PusherWebsocketDelegate.swift
+++ b/Sources/Extensions/PusherWebsocketDelegate.swift
@@ -162,36 +162,21 @@ extension PusherConnection: WebSocketConnectionDelegate {
     /// - Parameter strategy: The reconnection strategy for the reconnection attempt.
     internal func logReconnectionAttempt(strategy: PusherChannelsProtocolCloseCode.ReconnectionStrategy) {
 
-        if case .reconnectImmediately = strategy {
-            if reconnectAttemptsMax != nil {
-                let message = PusherLogger.debug(for: .attemptReconnectionImmediately,
-                                                 context: """
-                    (attempt \(reconnectAttempts + 1) of \(reconnectAttemptsMax!))
-                    """)
-                self.delegate?.debugLog?(message: message)
-            } else {
-                let message = PusherLogger.debug(for: .attemptReconnectionImmediately,
-                                                 context: """
-                    (attempt \(reconnectAttempts + 1))
-                    """)
-                self.delegate?.debugLog?(message: message)
-            }
-        } else {
-            let timeInterval = reconnectionAttemptTimeInterval(strategy: strategy)
-            if reconnectAttemptsMax != nil {
-                let message = PusherLogger.debug(for: .attemptReconnectionAfterWaiting,
-                                                 context: """
-                    \(timeInterval) seconds (attempt \(reconnectAttempts + 1) of \(reconnectAttemptsMax!))
-                    """)
-                self.delegate?.debugLog?(message: message)
-            } else {
-                let message = PusherLogger.debug(for: .attemptReconnectionAfterWaiting,
-                                                 context: """
-                    \(timeInterval) seconds (attempt \(reconnectAttempts + 1))
-                    """)
-                self.delegate?.debugLog?(message: message)
-            }
+        var context = "(attempt \(reconnectAttempts + 1))"
+        var loggingEvent = PusherLogger.LoggingEvent.attemptReconnectionImmediately
+
+        if reconnectAttemptsMax != nil {
+            context.insert(contentsOf: " of \(reconnectAttemptsMax!)", at: context.index(before: context.endIndex))
         }
+
+        if strategy != .reconnectImmediately {
+            loggingEvent = .attemptReconnectionAfterWaiting
+            let timeInterval = reconnectionAttemptTimeInterval(strategy: strategy)
+            context = "\(timeInterval) seconds " + context
+        }
+
+        self.delegate?.debugLog?(message: PusherLogger.debug(for: loggingEvent,
+                                                             context: context))
     }
 
     /// Logs the websocket disconnection event.

--- a/Sources/Extensions/PusherWebsocketDelegate.swift
+++ b/Sources/Extensions/PusherWebsocketDelegate.swift
@@ -72,8 +72,11 @@ extension PusherConnection: WebSocketConnectionDelegate {
 
         // Attempt reconnect if possible
 
-        guard self.options.autoReconnect else {
-            return
+        if case .privateCode = closeCode {} else {
+            // `autoReconnect` option is only respected if closeCode is outside the 4000-4999 range
+            guard self.options.autoReconnect else {
+                return
+            }
         }
 
         guard reconnectAttemptsMax == nil || reconnectAttempts < reconnectAttemptsMax! else {

--- a/Sources/Extensions/PusherWebsocketDelegate.swift
+++ b/Sources/Extensions/PusherWebsocketDelegate.swift
@@ -72,8 +72,8 @@ extension PusherConnection: WebSocketConnectionDelegate {
 
         // Attempt reconnect if possible
 
+        // `autoReconnect` option is ignored if the closure code is within the 4000-4999 range
         if case .privateCode = closeCode {} else {
-            // `autoReconnect` option is only respected if closeCode is outside the 4000-4999 range
             guard self.options.autoReconnect else {
                 return
             }

--- a/Sources/Helpers/PusherLogger.swift
+++ b/Sources/Helpers/PusherLogger.swift
@@ -31,6 +31,7 @@ internal class PusherLogger {
         case attemptReconnectionAfterReachabilityChange =
         "Connection state is 'connected' but received network reachability change so going to call attemptReconnect"
         case attemptReconnectionAfterWaiting = "Attempting to reconnect after waiting"
+        case attemptReconnectionImmediately = "Attempting to reconnect immediately"
         case connectionEstablished = "Socket established with socket ID:"
         case disconnectionWithoutError = "Websocket is disconnected but no error received"
         case errorReceived = "Websocket received error."

--- a/Sources/Models/WebSocket.swift
+++ b/Sources/Models/WebSocket.swift
@@ -21,7 +21,7 @@ open class WebSocket: WebSocketConnection {
 
     convenience init(request: URLRequest,
                      connectAutomatically: Bool = false,
-                     connectionQueue: DispatchQueue = .global(qos: .default)) {
+                     connectionQueue: DispatchQueue = .main) {
 
         self.init(url: request.url!,
                   connectAutomatically: connectAutomatically,
@@ -30,7 +30,7 @@ open class WebSocket: WebSocketConnection {
 
     init(url: URL,
          connectAutomatically: Bool = false,
-         connectionQueue: DispatchQueue = .global(qos: .default)) {
+         connectionQueue: DispatchQueue = .main) {
 
         endpoint = .url(url)
 

--- a/Sources/Models/WebSocket.swift
+++ b/Sources/Models/WebSocket.swift
@@ -19,28 +19,13 @@ open class WebSocket: WebSocketConnection {
 
     // MARK: - Initialization
 
-    init(request: URLRequest,
-         connectAutomatically: Bool = false,
-         connectionQueue: DispatchQueue = .global(qos: .default)) {
+    convenience init(request: URLRequest,
+                     connectAutomatically: Bool = false,
+                     connectionQueue: DispatchQueue = .global(qos: .default)) {
 
-        endpoint = .url(request.url!)
-
-        if request.url?.scheme == "ws" {
-            parameters = NWParameters.tcp
-        } else {
-            parameters = NWParameters.tls
-        }
-
-        let wsOptions = NWProtocolWebSocket.Options()
-        wsOptions.autoReplyPing = true
-        wsOptions.setSubprotocols([Self.webSocketSubProtocol])
-        parameters.defaultProtocolStack.applicationProtocols.insert(wsOptions, at: 0)
-
-        self.connectionQueue = connectionQueue
-
-        if connectAutomatically {
-            connect()
-        }
+        self.init(url: request.url!,
+                  connectAutomatically: connectAutomatically,
+                  connectionQueue: connectionQueue)
     }
 
     init(url: URL,

--- a/Sources/Models/WebSocket.swift
+++ b/Sources/Models/WebSocket.swift
@@ -144,7 +144,7 @@ open class WebSocket: WebSocketConnection {
     func disconnect(closeCode: NWProtocolWebSocket.CloseCode = .protocolCode(.normalClosure)) {
         let metadata = NWProtocolWebSocket.Metadata(opcode: .close)
         metadata.closeCode = closeCode
-        let context = NWConnection.ContentContext(identifier: "textContext", metadata: [metadata])
+        let context = NWConnection.ContentContext(identifier: "closeContext", metadata: [metadata])
 
         send(data: nil, context: context)
         delegate?.webSocketDidDisconnect(connection: self, closeCode: closeCode, reason: nil)

--- a/Sources/Models/WebSocket.swift
+++ b/Sources/Models/WebSocket.swift
@@ -106,6 +106,7 @@ open class WebSocket: WebSocketConnection {
 
             self.ping()
         }
+        pingTimer?.tolerance = 0.01
     }
 
     func ping() {

--- a/Sources/Protocols/WebSocketConnection.swift
+++ b/Sources/Protocols/WebSocketConnection.swift
@@ -1,44 +1,72 @@
 import Foundation
 import Network
 
-/// Defines a websocket connection.
+/// Defines a WebSocket connection.
 internal protocol WebSocketConnection {
-    /// Connect to the websocket.
+
+    /// Connect to the WebSocket.
     func connect()
 
-    /// Send a UTF-8 formatted `String` over the websocket.
+    /// Send a UTF-8 formatted `String` over the WebSocket.
     /// - Parameter string: The `String` that will be sent.
     func send(string: String)
 
-    /// Send some `Data` over the websocket.
+    /// Send some `Data` over the WebSocket.
     /// - Parameter data: The `Data` that will be sent.
     func send(data: Data)
 
-    /// Start listening for messages over the websocket.
+    /// Start listening for messages over the WebSocket.
     func listen()
 
-    /// Ping the websocket periodically.
+    /// Ping the WebSocket periodically.
     /// - Parameter interval: The `TimeInterval` (in seconds) with which to ping the server.
     func ping(interval: TimeInterval)
 
-    /// Ping the websocket once.
+    /// Ping the WebSocket once.
     func ping()
 
-    /// Disconnect from the websocket.
-    /// - Parameter closeCode: The code to use when closing the websocket connection.
+    /// Disconnect from the WebSocket.
+    /// - Parameter closeCode: The code to use when closing the WebSocket connection.
     func disconnect(closeCode: NWProtocolWebSocket.CloseCode)
 
     var delegate: WebSocketConnectionDelegate? { get set }
 }
 
-/// Defines a delegate for a websocket connection.
+/// Defines a delegate for a WebSocket connection.
 internal protocol WebSocketConnectionDelegate: AnyObject {
+
+    /// Called when the WebSocket has been established.
+    /// - Parameter connection: The `WebSocketConnection`.
     func webSocketDidConnect(connection: WebSocketConnection)
+
+    /// Called when the WebSocket has been disconnected.
+    /// - Parameters:
+    ///   - connection: The `WebSocketConnection`.
+    ///   - closeCode: The `NWProtocolWebSocket.CloseCode` reported during the connection closure.
+    ///   - reason: Optional informational `Data` reporting any addtional context for the closure.
     func webSocketDidDisconnect(connection: WebSocketConnection,
                                 closeCode: NWProtocolWebSocket.CloseCode,
                                 reason: Data?)
+
+    /// Called when an error was received during the WebSocket connection lifetime.
+    /// - Parameters:
+    ///   - connection: The `WebSocketConnection`.
+    ///   - error: The `Error` received by the `WebSocketConnection`.
     func webSocketDidReceiveError(connection: WebSocketConnection, error: Error)
+
+    /// Called when the WebSocket received a 'Pong' message.
+    /// - Parameter connection: The `WebSocketConnection`.
     func webSocketDidReceivePong(connection: WebSocketConnection)
+
+    /// Called when the WebSocket received a message with UTF-8 encoded `String` data attached.
+    /// - Parameters:
+    ///   - connection: The `WebSocketConnection`.
+    ///   - string: The `String` received in the message.
     func webSocketDidReceiveMessage(connection: WebSocketConnection, string: String)
+
+    /// Called when the WebSocket received a message binary `Data` attached.
+    /// - Parameters:
+    ///   - connection: The `WebSocketConnection`.
+    ///   - data: The `Data` received in the message.
     func webSocketDidReceiveMessage(connection: WebSocketConnection, data: Data)
 }

--- a/Tests/Helpers/Mocks.swift
+++ b/Tests/Helpers/Mocks.swift
@@ -14,9 +14,7 @@ open class MockWebSocket: WebSocket {
     var eventGivenToCallback: PusherEvent?
 
     init() {
-        var request = URLRequest(url: URL(string: "test")!)
-        request.timeoutInterval = 5
-        super.init(request: request)
+        super.init(url: URL(string: "test")!)
     }
 
     open func appendToCallbackCheckString(_ str: String) {

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -142,7 +142,6 @@ extension WebSocketTests: WebSocketConnectionDelegate {
 
         if receivedPongTimestamps.count == 5 {
             let timestampOffsets = zip(receivedPongTimestamps.dropFirst(), receivedPongTimestamps).map { $0.timeIntervalSince($1) }
-            print("DIFFS: \(timestampOffsets)")
             for offset in timestampOffsets {
                 XCTAssertEqual(offset, Self.repeatedPingInterval, accuracy: 0.1)
             }

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -48,7 +48,10 @@ class WebSocketTests: XCTestCase {
 
     var shouldDisconnectImmediately: Bool!
     var receivedPongTimestamps = [Date]()
+
     static let expectationTimeout = 5.0
+    static let stringMessage = "This is a string message!"
+    static let dataMessage = "This is a data message!".data(using: .utf8)!
 
     override func setUp() {
         super.setUp()
@@ -74,14 +77,14 @@ class WebSocketTests: XCTestCase {
     func testReceiveStringMessage() {
         stringMessageExpectation = XCTestExpectation(description: "stringMessageExpectation")
         socket.connect()
-        socket.send(string: "This is a string message!")
+        socket.send(string: Self.stringMessage)
         wait(for: [stringMessageExpectation], timeout: Self.expectationTimeout)
     }
 
     func testReceiveDataMessage() {
         dataMessageExpectation = XCTestExpectation(description: "dataMessageExpectation")
         socket.connect()
-        socket.send(data: "This is a data message!".data(using: .utf8)!)
+        socket.send(data: Self.dataMessage)
         wait(for: [dataMessageExpectation], timeout: Self.expectationTimeout)
     }
 
@@ -146,12 +149,12 @@ extension WebSocketTests: WebSocketConnectionDelegate {
     }
 
     func webSocketDidReceiveMessage(connection: WebSocketConnection, string: String) {
-        XCTAssertEqual(string, "This is a string message!")
+        XCTAssertEqual(string, Self.stringMessage)
         stringMessageExpectation.fulfill()
     }
 
     func webSocketDidReceiveMessage(connection: WebSocketConnection, data: Data) {
-        XCTAssertEqual(data, "This is a data message!".data(using: .utf8))
+        XCTAssertEqual(data, Self.dataMessage)
         dataMessageExpectation.fulfill()
     }
 }

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -49,7 +49,7 @@ class WebSocketTests: XCTestCase {
     var shouldDisconnectImmediately: Bool!
     var receivedPongTimestamps = [Date]()
     static let expectationTimeout = 5.0
-    static let repeatedPingInterval = 0.5
+    static let repeatedPingInterval = 1.0
 
     override func setUp() {
         super.setUp()
@@ -97,7 +97,7 @@ class WebSocketTests: XCTestCase {
         pingsWithIntervalExpectation = XCTestExpectation(description: "pingsWithIntervalExpectation")
         socket.connect()
         socket.ping(interval: Self.repeatedPingInterval)
-        wait(for: [pingsWithIntervalExpectation!], timeout: Self.expectationTimeout)
+        wait(for: [pingsWithIntervalExpectation!], timeout: Self.expectationTimeout * 2)
     }
 
     func testReceiveError() {
@@ -142,8 +142,9 @@ extension WebSocketTests: WebSocketConnectionDelegate {
 
         if receivedPongTimestamps.count == 5 {
             let timestampOffsets = zip(receivedPongTimestamps.dropFirst(), receivedPongTimestamps).map { $0.timeIntervalSince($1) }
+            print("DIFFS: \(timestampOffsets)")
             for offset in timestampOffsets {
-                XCTAssertEqual(offset, Self.repeatedPingInterval, accuracy: 0.01)
+                XCTAssertEqual(offset, Self.repeatedPingInterval, accuracy: 0.1)
             }
             pingsWithIntervalExpectation?.fulfill()
         }

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -7,8 +7,6 @@ import Network
     @testable import PusherSwift
 #endif
 
-// swiftlint:disable todo
-
 class WebSocketTests: XCTestCase {
     var socket: WebSocket!
 
@@ -93,7 +91,6 @@ class WebSocketTests: XCTestCase {
 
         errorExpectation = XCTestExpectation(description: "errorExpectation")
         socket.connect()
-        // TODO: TRIGGER ERROR
         wait(for: [errorExpectation!], timeout: Self.expectationTimeout)
     }
 

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -102,7 +102,7 @@ class WebSocketTests: XCTestCase {
 
     func testReceiveError() {
         // Redefine socket with invalid path
-        socket = WebSocket(url: URL(string: "wss://echo.websocket.org/abc")!)
+        socket = WebSocket(request: URLRequest(url: URL(string: "wss://echo.websocket.org/abc")!))
         socket.delegate = self
 
         errorExpectation = XCTestExpectation(description: "errorExpectation")

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import Network
+
+#if WITH_ENCRYPTION
+    @testable import PusherSwiftWithEncryption
+#else
+    @testable import PusherSwift
+#endif
+
+// swiftlint:disable todo
+
+class WebSocketTests: XCTestCase {
+    var socket: WebSocket!
+
+    var connectExpectation: XCTestExpectation? {
+        didSet {
+            shouldDisconnectImmediately = false
+        }
+    }
+    var disconnectExpectation: XCTestExpectation! {
+        didSet {
+            shouldDisconnectImmediately = true
+        }
+    }
+    var stringMessageExpectation: XCTestExpectation! {
+        didSet {
+            shouldDisconnectImmediately = false
+        }
+    }
+    var dataMessageExpectation: XCTestExpectation! {
+        didSet {
+            shouldDisconnectImmediately = false
+        }
+    }
+    var pongExpectation: XCTestExpectation! {
+        didSet {
+            shouldDisconnectImmediately = false
+        }
+    }
+    var errorExpectation: XCTestExpectation? {
+        didSet {
+            shouldDisconnectImmediately = false
+        }
+    }
+
+    var shouldDisconnectImmediately: Bool!
+
+    override func setUp() {
+        super.setUp()
+
+        socket = WebSocket(url: URL(string: "wss://echo.websocket.org")!)
+        socket.delegate = self
+    }
+
+    func testConnect() {
+        connectExpectation = XCTestExpectation(description: "connectExpectation")
+        socket.connect()
+        wait(for: [connectExpectation!], timeout: 1.0)
+    }
+
+    func testDisconnect() {
+        disconnectExpectation = XCTestExpectation(description: "disconnectExpectation")
+        socket.connect()
+        wait(for: [disconnectExpectation], timeout: 1.0)
+    }
+
+    func testReceiveStringMessage() {
+        stringMessageExpectation = XCTestExpectation(description: "stringMessageExpectation")
+        socket.connect()
+        socket.send(string: "This is a string message!")
+        wait(for: [stringMessageExpectation], timeout: 1.0)
+    }
+
+    func testReceiveDataMessage() {
+        dataMessageExpectation = XCTestExpectation(description: "dataMessageExpectation")
+        socket.connect()
+        socket.send(data: "This is a data message!".data(using: .utf8)!)
+        wait(for: [dataMessageExpectation], timeout: 1.0)
+    }
+
+    func testReceivePong() {
+        pongExpectation = XCTestExpectation(description: "pongExpectation")
+        socket.connect()
+        socket.ping()
+        wait(for: [pongExpectation], timeout: 1.0)
+    }
+
+    func testReceiveError() {
+        // Redefine socket with invalid path
+        socket = WebSocket(url: URL(string: "wss://echo.websocket.org/abc")!)
+        socket.delegate = self
+
+        errorExpectation = XCTestExpectation(description: "errorExpectation")
+        socket.connect()
+        // TODO: TRIGGER ERROR
+        wait(for: [errorExpectation!], timeout: 1.0)
+    }
+
+}
+
+// MARK: - WebSocketConnectionDelegate conformance
+
+extension WebSocketTests: WebSocketConnectionDelegate {
+
+    func webSocketDidConnect(connection: WebSocketConnection) {
+        connectExpectation?.fulfill()
+        if shouldDisconnectImmediately {
+            socket.disconnect()
+        }
+    }
+
+    func webSocketDidDisconnect(connection: WebSocketConnection,
+                                closeCode: NWProtocolWebSocket.CloseCode, reason: Data?) {
+        disconnectExpectation.fulfill()
+    }
+
+    func webSocketDidReceiveError(connection: WebSocketConnection, error: Error) {
+        errorExpectation?.fulfill()
+    }
+
+    func webSocketDidReceivePong(connection: WebSocketConnection) {
+        pongExpectation.fulfill()
+    }
+
+    func webSocketDidReceiveMessage(connection: WebSocketConnection, string: String) {
+        XCTAssertEqual(string, "This is a string message!")
+        stringMessageExpectation.fulfill()
+    }
+
+    func webSocketDidReceiveMessage(connection: WebSocketConnection, data: Data) {
+        XCTAssertEqual(data, "This is a data message!".data(using: .utf8))
+        dataMessageExpectation.fulfill()
+    }
+}

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -44,6 +44,7 @@ class WebSocketTests: XCTestCase {
     }
 
     var shouldDisconnectImmediately: Bool!
+    static let expectationTimeout = 5.0
 
     override func setUp() {
         super.setUp()
@@ -55,34 +56,34 @@ class WebSocketTests: XCTestCase {
     func testConnect() {
         connectExpectation = XCTestExpectation(description: "connectExpectation")
         socket.connect()
-        wait(for: [connectExpectation!], timeout: 1.0)
+        wait(for: [connectExpectation!], timeout: Self.expectationTimeout)
     }
 
     func testDisconnect() {
         disconnectExpectation = XCTestExpectation(description: "disconnectExpectation")
         socket.connect()
-        wait(for: [disconnectExpectation], timeout: 1.0)
+        wait(for: [disconnectExpectation], timeout: Self.expectationTimeout)
     }
 
     func testReceiveStringMessage() {
         stringMessageExpectation = XCTestExpectation(description: "stringMessageExpectation")
         socket.connect()
         socket.send(string: "This is a string message!")
-        wait(for: [stringMessageExpectation], timeout: 1.0)
+        wait(for: [stringMessageExpectation], timeout: Self.expectationTimeout)
     }
 
     func testReceiveDataMessage() {
         dataMessageExpectation = XCTestExpectation(description: "dataMessageExpectation")
         socket.connect()
         socket.send(data: "This is a data message!".data(using: .utf8)!)
-        wait(for: [dataMessageExpectation], timeout: 1.0)
+        wait(for: [dataMessageExpectation], timeout: Self.expectationTimeout)
     }
 
     func testReceivePong() {
         pongExpectation = XCTestExpectation(description: "pongExpectation")
         socket.connect()
         socket.ping()
-        wait(for: [pongExpectation], timeout: 1.0)
+        wait(for: [pongExpectation], timeout: Self.expectationTimeout)
     }
 
     func testReceiveError() {
@@ -93,7 +94,7 @@ class WebSocketTests: XCTestCase {
         errorExpectation = XCTestExpectation(description: "errorExpectation")
         socket.connect()
         // TODO: TRIGGER ERROR
-        wait(for: [errorExpectation!], timeout: 1.0)
+        wait(for: [errorExpectation!], timeout: Self.expectationTimeout)
     }
 
 }

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -47,17 +47,19 @@ class WebSocketTests: XCTestCase {
     }
 
     var shouldDisconnectImmediately: Bool!
-    var receivedPongTimestamps = [Date]()
+    var receivedPongTimestamps: [Date]!
 
     static let expectationTimeout = 5.0
     static let stringMessage = "This is a string message!"
     static let dataMessage = "This is a data message!".data(using: .utf8)!
+    static let expectedReceivedPongsCount = 3
 
     override func setUp() {
         super.setUp()
 
         socket = WebSocket(url: URL(string: "wss://echo.websocket.org")!)
         socket.delegate = self
+        receivedPongTimestamps = []
     }
 
     // MARK: - Test methods
@@ -142,7 +144,7 @@ extension WebSocketTests: WebSocketConnectionDelegate {
             return
         }
 
-        if receivedPongTimestamps.count == 3 {
+        if receivedPongTimestamps.count == Self.expectedReceivedPongsCount {
             pingsWithIntervalExpectation?.fulfill()
         }
         receivedPongTimestamps.append(Date())

--- a/Tests/Unit/Models/WebSocketTests.swift
+++ b/Tests/Unit/Models/WebSocketTests.swift
@@ -49,7 +49,6 @@ class WebSocketTests: XCTestCase {
     var shouldDisconnectImmediately: Bool!
     var receivedPongTimestamps = [Date]()
     static let expectationTimeout = 5.0
-    static let repeatedPingInterval = 1.0
 
     override func setUp() {
         super.setUp()
@@ -96,8 +95,8 @@ class WebSocketTests: XCTestCase {
     func testPingsWithInterval() {
         pingsWithIntervalExpectation = XCTestExpectation(description: "pingsWithIntervalExpectation")
         socket.connect()
-        socket.ping(interval: Self.repeatedPingInterval)
-        wait(for: [pingsWithIntervalExpectation!], timeout: Self.expectationTimeout * 2)
+        socket.ping(interval: 0.5)
+        wait(for: [pingsWithIntervalExpectation!], timeout: Self.expectationTimeout)
     }
 
     func testReceiveError() {
@@ -140,11 +139,7 @@ extension WebSocketTests: WebSocketConnectionDelegate {
             return
         }
 
-        if receivedPongTimestamps.count == 5 {
-            let timestampOffsets = zip(receivedPongTimestamps.dropFirst(), receivedPongTimestamps).map { $0.timeIntervalSince($1) }
-            for offset in timestampOffsets {
-                XCTAssertEqual(offset, Self.repeatedPingInterval, accuracy: 0.1)
-            }
+        if receivedPongTimestamps.count == 3 {
             pingsWithIntervalExpectation?.fulfill()
         }
         receivedPongTimestamps.append(Date())

--- a/iOS Example Obj-C/iOS Example Obj-C.xcodeproj/project.pbxproj
+++ b/iOS Example Obj-C/iOS Example Obj-C.xcodeproj/project.pbxproj
@@ -192,7 +192,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/../Carthage/Build/iOS/Reachability.framework",
-				"$(SRCROOT)/../Carthage/Build/iOS/Starscream.framework",
 			);
 			name = "Copy Carthage Frameworks";
 			outputFileListPaths = (
@@ -351,6 +350,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = H7FL434D9W;
 				INFOPLIST_FILE = "iOS Example Obj-C/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pusher.iOS-Example-Obj-C";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -364,6 +364,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = H7FL434D9W;
 				INFOPLIST_FILE = "iOS Example Obj-C/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pusher.iOS-Example-Obj-C";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/iOS Example Swift/iOS Example Swift.xcodeproj/project.pbxproj
+++ b/iOS Example Swift/iOS Example Swift.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		33831CC41A9CFCDB00B124F1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 33831CC01A9CFCDB00B124F1 /* Main.storyboard */; };
 		33831CC51A9CFCDB00B124F1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33831CC11A9CFCDB00B124F1 /* ViewController.swift */; };
 		33CC82EB1D7F16A8003B699F /* PusherSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33CC82EA1D7F16A8003B699F /* PusherSwift.framework */; };
-		33E94E7620766DBE0005399D /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 335AD5A920569C3B000D4D08 /* Starscream.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -58,7 +57,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				33E94E7620766DBE0005399D /* Starscream.framework in Frameworks */,
 				335AD5AC20569C3C000D4D08 /* Reachability.framework in Frameworks */,
 				33CC82EB1D7F16A8003B699F /* PusherSwift.framework in Frameworks */,
 			);
@@ -201,7 +199,6 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/../Carthage/Build/iOS/Reachability.framework",
-				"$(SRCROOT)/../Carthage/Build/iOS/Starscream.framework",
 			);
 			name = "Copy Carthage Frameworks";
 			outputPaths = (
@@ -273,7 +270,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -324,7 +321,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -343,7 +340,7 @@
 				DEVELOPMENT_TEAM = H7FL434D9W;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "iOS Example Swift/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pusher.iOS-Example-Obj-C";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -364,7 +361,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_OPTIMIZATION_LEVEL = s;
 				INFOPLIST_FILE = "iOS Example Swift/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pusher.iOS-Example-Obj-C";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
This PR resolves #222 

- Replaces the implementation of `WebSocket` using `Network.framework`, which is a lower-level native API that exposes all received closure codes whereas `URLSessionWebSocketTask` does not.
  - This is covered by the new `WebSocketTests.swift`.
- Adds logic to `WebSocketConnectionDelegate.swift` to explicitly handle the appropriate reconnection attempt cases presented by Pusher Channels Protocol custom closure codes.
  - **N.B: The `autoReconnect` option is now ignored if the closure code is within the 4000-4999 range** (i.e. the behaviour is determined instead by the received [Channels Protocol closure code](https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#connection-closure)).
  - This is covered by new unit tests in `PusherConnectionDelegateTests`.
- Ensures the Swift and Objective-C example apps compile correctly by updating their iOS minimum deployment target settings.
- Improves Apple Quick Help documentation for `WebSocketConnection` and `WebSocketConnectionDelegate`.