### PR TITLE
Refactor some 'if let' statments to 'guard let'

### DIFF
--- a/Sources/Models/PusherChannel.swift
+++ b/Sources/Models/PusherChannel.swift
@@ -128,9 +128,11 @@ open class PusherChannel: NSObject {
         - parameter callbackId: The unique callbackId string used to identify which callback to unbind
     */
     open func unbind(eventName: String, callbackId: String) {
-        if let eventSpecificHandlers = self.eventHandlers[eventName] {
-            self.eventHandlers[eventName] = eventSpecificHandlers.filter({ $0.id != callbackId })
+        guard let eventSpecificHandlers = self.eventHandlers[eventName] else {
+            return
         }
+
+        self.eventHandlers[eventName] = eventSpecificHandlers.filter({ $0.id != callbackId })
     }
 
     /**
@@ -155,11 +157,13 @@ open class PusherChannel: NSObject {
         - parameter event: The event received from the websocket
     */
     open func handleEvent(event: PusherEvent) {
-        if let eventHandlerArray = self.eventHandlers[event.eventName] {
-            for eventHandler in eventHandlerArray {
-                // swiftlint:disable:next force_cast
-                eventHandler.callback(event.copy() as! PusherEvent)
-            }
+        guard let eventHandlerArray = self.eventHandlers[event.eventName] else {
+            return
+        }
+
+        for eventHandler in eventHandlerArray {
+            // swiftlint:disable:next force_cast
+            eventHandler.callback(event.copy() as! PusherEvent)
         }
     }
 

--- a/Sources/Models/PusherPresenceChannel.swift
+++ b/Sources/Models/PusherPresenceChannel.swift
@@ -101,11 +101,13 @@ public typealias PusherUserInfoObject = [String: AnyObject]
             id = String.init(describing: memberJSON[Constants.JSONKeys.userId]!)
         }
 
-        if let index = self.members.firstIndex(where: { $0.userId == id }) {
-            let member = self.members[index]
-            self.members.remove(at: index)
-            self.onMemberRemoved?(member)
+        guard let index = self.members.firstIndex(where: { $0.userId == id }) else {
+            return
         }
+
+        let member = self.members[index]
+        self.members.remove(at: index)
+        self.onMemberRemoved?(member)
     }
 
     /**
@@ -116,10 +118,12 @@ public typealias PusherUserInfoObject = [String: AnyObject]
                                  to the channel
     */
     internal func setMyUserId(channelData: String) {
-        if let channelDataObject = parse(channelData: channelData),
-            let userId = channelDataObject[Constants.JSONKeys.userId] {
-            self.myId = String.init(describing: userId)
+        guard let channelDataObject = parse(channelData: channelData),
+            let userId = channelDataObject[Constants.JSONKeys.userId] else {
+            return
         }
+
+        self.myId = String.init(describing: userId)
     }
 
     /**
@@ -164,11 +168,11 @@ public typealias PusherUserInfoObject = [String: AnyObject]
         - returns: The connected user's PusherPresenceChannelMember object
     */
     open func me() -> PusherPresenceChannelMember? {
-        if let id = self.myId {
-            return findMember(userId: id)
-        } else {
+        guard let id = self.myId else {
             return nil
         }
+
+        return findMember(userId: id)
     }
 }
 

--- a/Sources/ObjC/ObjectiveC.swift
+++ b/Sources/ObjC/ObjectiveC.swift
@@ -215,10 +215,10 @@ public extension AuthMethod {
 public extension PusherError {
     /// The error code as an NSNumber (for Objective-C compatibility).
     var codeOC: NSNumber? {
-        if let code = code {
-            return NSNumber(value: code)
-        } else {
+        guard let code = code else {
             return nil
         }
+
+        return NSNumber(value: code)
     }
 }

--- a/Tests/Helpers/Helpers.swift
+++ b/Tests/Helpers/Helpers.swift
@@ -3,15 +3,18 @@ import Foundation
 @testable import PusherSwift
 
 func convertStringToDictionary(_ text: String) -> [String: AnyObject]? {
-    if let data = text.data(using: .utf8) {
-        do {
-            let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: AnyObject]
-            return json
-        } catch {
-            print("Something went wrong")
-        }
+    guard let data = text.data(using: .utf8) else {
+        return nil
     }
-    return nil
+
+    do {
+        let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: AnyObject]
+        return json
+    } catch {
+        print("Something went wrong")
+        
+        return nil
+    }
 }
 
 extension AuthMethod: Equatable {

--- a/Tests/Integration/AuthenticationTests.swift
+++ b/Tests/Integration/AuthenticationTests.swift
@@ -10,9 +10,11 @@ class AuthenticationTests: XCTestCase {
         var testingChannelName: String?
 
         func subscribedToChannel(name: String) {
-            if let cName = testingChannelName, cName == name {
-                ex!.fulfill()
+            guard let cName = testingChannelName, cName == name else {
+                return
             }
+
+            ex!.fulfill()
         }
     }
 
@@ -126,11 +128,15 @@ class AuthenticationTests: XCTestCase {
         XCTAssertFalse(chan.subscribed, "the channel should not be subscribed")
 
         _ = pusher.bind({ (data: Any?) -> Void in
-            if let data = data as? [String: AnyObject], let eventName = data["event"] as? String, eventName == "pusher:subscription_error" {
-                XCTAssertEqual("private-test-channel", data["channel"] as? String)
-                XCTAssertTrue(Thread.isMainThread)
-                ex.fulfill()
+            guard let data = data as? [String: AnyObject],
+                  let eventName = data["event"] as? String,
+                  eventName == "pusher:subscription_error" else {
+                return
             }
+            
+            XCTAssertEqual("private-test-channel", data["channel"] as? String)
+            XCTAssertTrue(Thread.isMainThread)
+            ex.fulfill()
         })
 
         pusher.connect()

--- a/Tests/Integration/PusherIncomingEventHandlingTests.swift
+++ b/Tests/Integration/PusherIncomingEventHandlingTests.swift
@@ -235,12 +235,16 @@ class HandlingIncomingEventsTests: XCTestCase {
         let ex = expectation(description: "Callback should be called")
 
         _ = pusher.bind({ (message: Any?) in
-            if let message = message as? [String: AnyObject], let eventName = message["event"] as? String, eventName == "pusher:error" {
-                if let data = message["data"] as? [String: AnyObject], let errorMessage = data["message"] as? String {
-                    XCTAssertEqual(errorMessage, "Existing subscription to channel my-channel")
-                    ex.fulfill()
-                }
+            guard let message = message as? [String: AnyObject],
+               let eventName = message["event"] as? String,
+               eventName == "pusher:error",
+               let data = message["data"] as? [String: AnyObject],
+               let errorMessage = data["message"] as? String else {
+                return
             }
+
+            XCTAssertEqual(errorMessage, "Existing subscription to channel my-channel")
+            ex.fulfill()
         })
         // pretend that we tried to subscribe to my-channel twice and got this error
         // back from Pusher

--- a/Tests/Unit/Models/ClientEventTests.swift
+++ b/Tests/Unit/Models/ClientEventTests.swift
@@ -47,12 +47,14 @@ class ClientEventTests: XCTestCase {
         let ex = expectation(description: "send client event eventually")
         socket.stubber.registerCallback { calls in
             let expectedDict = ["data": ["data": "testing client events"], "event": "client-test-event", "channel": "private-channel"] as [String: Any]
-            if let lastCall = calls.last, lastCall.name == "writeString" {
-                let parsedSubscribeArgs = convertStringToDictionary(lastCall.args!.first as! String)
-                let parsedEqualsExpected = NSDictionary(dictionary: parsedSubscribeArgs!).isEqual(to: NSDictionary(dictionary: expectedDict) as [NSObject: AnyObject])
-                if parsedEqualsExpected {
-                    ex.fulfill()
-                }
+            guard let lastCall = calls.last, lastCall.name == "writeString" else {
+                return
+            }
+
+            let parsedSubscribeArgs = convertStringToDictionary(lastCall.args!.first as! String)
+            let parsedEqualsExpected = NSDictionary(dictionary: parsedSubscribeArgs!).isEqual(to: NSDictionary(dictionary: expectedDict) as [NSObject: AnyObject])
+            if parsedEqualsExpected {
+                ex.fulfill()
             }
         }
         connection.connect()
@@ -71,13 +73,15 @@ class ClientEventTests: XCTestCase {
 
         let ex = expectation(description: "send client event eventually")
         socket.stubber.registerCallback { calls in
-            if let lastCall = calls.last, lastCall.name == "writeString" {
-                let parsedSubscribeArgs = convertStringToDictionary(lastCall.args!.first as! String)
-                let expectedDict = ["data": ["data": "more testing client events"], "event": "client-test-event", "channel": "private-channel"] as [String: Any]
-                let parsedEqualsExpected = NSDictionary(dictionary: parsedSubscribeArgs!).isEqual(to: NSDictionary(dictionary: expectedDict) as [NSObject: AnyObject])
-                if parsedEqualsExpected {
-                    ex.fulfill()
-                }
+            guard let lastCall = calls.last, lastCall.name == "writeString" else {
+                return
+            }
+
+            let parsedSubscribeArgs = convertStringToDictionary(lastCall.args!.first as! String)
+            let expectedDict = ["data": ["data": "more testing client events"], "event": "client-test-event", "channel": "private-channel"] as [String: Any]
+            let parsedEqualsExpected = NSDictionary(dictionary: parsedSubscribeArgs!).isEqual(to: NSDictionary(dictionary: expectedDict) as [NSObject: AnyObject])
+            if parsedEqualsExpected {
+                ex.fulfill()
             }
 
         }

--- a/Tests/Unit/Protocols/PusherConnectionDelegateTests.swift
+++ b/Tests/Unit/Protocols/PusherConnectionDelegateTests.swift
@@ -24,15 +24,19 @@ class PusherConnectionDelegateTests: XCTestCase {
         }
 
         open func subscribedToChannel(name: String) {
-            if let cName = testingChannelName, cName == name {
-                ex!.fulfill()
+            guard let cName = testingChannelName, cName == name else {
+                return
             }
+
+            ex!.fulfill()
         }
 
         open func failedToSubscribeToChannel(name: String, response: URLResponse?, data: String?, error: NSError?) {
-            if let cName = testingChannelName, cName == name {
-                ex!.fulfill()
+            guard let cName = testingChannelName, cName == name else {
+                return
             }
+
+            ex!.fulfill()
         }
 
         open func receivedError(error: PusherError) {


### PR DESCRIPTION
This PR resolves #321

- Refactors some cases of `if let` where `guard let` would be more appropriate for Swift best practices.

**NOTES:**

- These changes improve readability by where methods can return early, and allowing focus on the "happy path" of the method.
