### PR TITLE
Refactor 'print()' logging to use 'PusherLogger'

### DIFF
--- a/Sources/Extensions/PusherWebsocketDelegate.swift
+++ b/Sources/Extensions/PusherWebsocketDelegate.swift
@@ -11,19 +11,20 @@ extension PusherConnection: WebSocketConnectionDelegate {
         - parameter string: The message received over the websocket
     */
     public func webSocketDidReceiveMessage(connection: WebSocketConnection, string: String) {
-        self.delegate?.debugLog?(message: PusherLogger.debug(for: .receivedMessage, context: string))
+        PusherLogger.shared.debug(for: .receivedMessage, context: string)
 
         guard let payload = PusherParser.getPusherEventJSON(from: string),
             let event = payload[Constants.JSONKeys.event] as? String
         else {
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToHandleIncomingMessage, context: string))
+            PusherLogger.shared.debug(for: .unableToHandleIncomingMessage,
+                                      context: string)
             return
         }
 
         if event == Constants.Events.Pusher.error {
             guard let error = PusherError(jsonObject: payload) else {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToHandleIncomingError,
-                                                                     context: string))
+                PusherLogger.shared.debug(for: .unableToHandleIncomingError,
+                                          context: string)
                 return
             }
             self.handleError(error: error)
@@ -35,7 +36,7 @@ extension PusherConnection: WebSocketConnectionDelegate {
     /// Delegate method called when a pong is received over a websocket
     /// - Parameter connection: The websocket that has received the pong
     public func webSocketDidReceivePong(connection: WebSocketConnection) {
-        self.delegate?.debugLog?(message: PusherLogger.debug(for: .pongReceived))
+        PusherLogger.shared.debug(for: .pongReceived)
         resetActivityTimeoutTimer()
     }
 
@@ -63,7 +64,7 @@ extension PusherConnection: WebSocketConnectionDelegate {
         updateConnectionState(to: .disconnected)
 
         guard !intentionalDisconnect else {
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .intentionalDisconnection))
+            PusherLogger.shared.debug(for: .intentionalDisconnection)
             return
         }
 
@@ -81,7 +82,7 @@ extension PusherConnection: WebSocketConnectionDelegate {
         }
 
         guard reconnectAttemptsMax == nil || reconnectAttempts < reconnectAttemptsMax! else {
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .maxReconnectAttemptsLimitReached))
+            PusherLogger.shared.debug(for: .maxReconnectAttemptsLimitReached)
             return
         }
 
@@ -90,9 +91,9 @@ extension PusherConnection: WebSocketConnectionDelegate {
 
     public func webSocketViabilityDidChange(connection: WebSocketConnection, isViable: Bool) {
         if isViable {
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .networkConnectionViable))
+            PusherLogger.shared.debug(for: .networkConnectionViable)
         } else {
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .networkConnectionUnviable))
+            PusherLogger.shared.debug(for: .networkConnectionUnviable)
         }
     }
 
@@ -101,10 +102,10 @@ extension PusherConnection: WebSocketConnectionDelegate {
         case .success:
             updateConnectionState(to: .reconnecting)
         case .failure(let error):
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .errorReceived,
-                                                                 context: """
+            PusherLogger.shared.debug(for: .errorReceived,
+                                      context: """
                 Path migration error: \(error.debugDescription)
-                """))
+                """)
         }
     }
 
@@ -187,8 +188,8 @@ extension PusherConnection: WebSocketConnectionDelegate {
             context = "\(timeInterval) seconds " + context
         }
 
-        self.delegate?.debugLog?(message: PusherLogger.debug(for: loggingEvent,
-                                                             context: context))
+        PusherLogger.shared.debug(for: loggingEvent,
+                                  context: context)
     }
 
     /// Logs the websocket disconnection event.
@@ -214,8 +215,8 @@ extension PusherConnection: WebSocketConnectionDelegate {
             closeMessage += " Reason: \(reasonString)."
         }
 
-        self.delegate?.debugLog?(message: PusherLogger.debug(for: .disconnectionWithoutError,
-                                                             context: closeMessage))
+        PusherLogger.shared.debug(for: .disconnectionWithoutError,
+                                  context: closeMessage)
     }
 
     /**
@@ -232,9 +233,9 @@ extension PusherConnection: WebSocketConnectionDelegate {
     }
 
     public func webSocketDidReceiveError(connection: WebSocketConnection, error: NWError) {
-        self.delegate?.debugLog?(message: PusherLogger.debug(for: .errorReceived,
-                                                             context: """
+        PusherLogger.shared.debug(for: .errorReceived,
+                                  context: """
             Error: \(error.debugDescription)
-            """))
+            """)
     }
 }

--- a/Sources/Helpers/PusherLogger.swift
+++ b/Sources/Helpers/PusherLogger.swift
@@ -13,12 +13,18 @@ internal class PusherLogger {
         case presenceChannelSubscriptionAttemptWithoutChannelData =
         "Attempting to subscribe to presence channel but no channelData value provided"
         case subscriptionSucceededNoDataInPayload = "Subscription succeeded event received without data key in payload"
+        case unableToSubscribeToChannel = "Unable to subscribe to channel:"
+        case unableToAddMemberToChannel = "Unable to add member to channel"
+        case unableToRemoveMemberFromChannel = "Unable to remove member from channel"
+        case authInfoForCompletionHandlerIsNil = "Auth info passed to authorizer completionHandler was nil"
+        case authenticationFailed = "Authentication failed. You may not be connected"
 
         // Events
 
         case clientEventSent = "sendClientEvent"
         case eventSent = "sendEvent"
         case skippedEventAfterDecryptionFailure = "Skipping event that failed to decrypt on channel"
+        case cannotSendClientEventForChannel = "You must be subscribed to a private or presence channel to send client events"
 
         // Network
 

--- a/Sources/Helpers/PusherLogger.swift
+++ b/Sources/Helpers/PusherLogger.swift
@@ -54,63 +54,62 @@ internal class PusherLogger {
         case error      = "[PUSHER ERROR]"
     }
 
+    internal static let shared = PusherLogger()
+
+    internal weak var delegate: PusherDelegate?
+
     // MARK: - Event logging
 
-    /// A debug message relating to a particular event of interest.
+    /// Logs a debug message relating to a particular event of interest.
     /// - Parameters:
     ///   - event: A particular `LoggingEvent` of interest.
     ///   - context: Additional context for the message.
-    /// - Returns: A `String` with information to log concerning the event.
-    internal static func debug(for event: LoggingEvent,
-                               context: CustomStringConvertible? = nil) -> String {
-        return message(for: event, level: .debug, context: context)
+    internal func debug(for event: LoggingEvent,
+                        context: CustomStringConvertible? = nil) {
+        message(for: event, level: .debug, context: context)
     }
 
-    /// An informational message relating to a particular event of interest.
+    /// Logs an informational message relating to a particular event of interest.
     /// - Parameters:
     ///   - event: A particular `LoggingEvent` of interest.
     ///   - context: Additional context for the message.
-    /// - Returns: A `String` with information to log concerning the event.
-    internal static func info(for event: LoggingEvent,
-                              context: CustomStringConvertible? = nil) -> String {
-        return message(for: event, level: .info, context: context)
+    internal func info(for event: LoggingEvent,
+                       context: CustomStringConvertible? = nil) {
+        message(for: event, level: .info, context: context)
     }
 
-    /// A warning message relating to a particular event of interest.
+    /// Logs a warning message relating to a particular event of interest.
     /// - Parameters:
     ///   - event: A particular `LoggingEvent` of interest.
     ///   - context: Additional context for the message.
-    /// - Returns: A `String` with information to log concerning the event.
-    internal static func warning(for event: LoggingEvent,
-                                 context: CustomStringConvertible? = nil) -> String {
-        return message(for: event, level: .warning, context: context)
+    internal func warning(for event: LoggingEvent,
+                          context: CustomStringConvertible? = nil) {
+        message(for: event, level: .warning, context: context)
     }
 
-    /// An error message relating to a particular event of interest.
+    /// Logs an error message relating to a particular event of interest.
     /// - Parameters:
     ///   - event: A particular `LoggingEvent` of interest.
     ///   - context: Additional context for the message.
-    /// - Returns: A `String` with information to log concerning the event.
-    internal static func error(for event: LoggingEvent,
-                               context: CustomStringConvertible? = nil) -> String {
-        return message(for: event, level: .error, context: context)
+    internal func error(for event: LoggingEvent,
+                        context: CustomStringConvertible? = nil) {
+        message(for: event, level: .error, context: context)
     }
 
     // MARK: - Private methods
 
-    /// An informational message relating to a particular event of interest.
+    /// Logs an informational message relating to a particular event of interest.
     /// - Parameter event: A particular `LoggingEvent` of interest.
     /// - Parameter level: The `LoggingLevel` to set for the message.
     /// - Parameter context: Additional context for the message.
-    /// - Returns: A `String` with information to log concerning the event.
-    private static func message(for event: LoggingEvent,
-                                level: LoggingLevel,
-                                context: CustomStringConvertible? = nil) -> String {
+    private func message(for event: LoggingEvent,
+                         level: LoggingLevel,
+                         context: CustomStringConvertible? = nil) {
         var message = "\(level.rawValue) \(event.rawValue)"
         if let context = context {
             message += " \(context)"
         }
 
-        return message
+        self.delegate?.debugLog?(message: message)
     }
 }

--- a/Sources/Helpers/PusherLogger.swift
+++ b/Sources/Helpers/PusherLogger.swift
@@ -18,6 +18,11 @@ internal class PusherLogger {
         case unableToRemoveMemberFromChannel = "Unable to remove member from channel"
         case authInfoForCompletionHandlerIsNil = "Auth info passed to authorizer completionHandler was nil"
         case authenticationFailed = "Authentication failed. You may not be connected"
+        case authValueOnSubscriptionNotSupported = """
+            Passing an auth value to 'subscribe' is not supported for encrypted channels. \
+            Event decryption will fail. You must use one of the following auth methods: \
+            'endpoint', 'authRequestBuilder', 'authorizer'
+            """
 
         // Events
 
@@ -25,6 +30,15 @@ internal class PusherLogger {
         case eventSent = "sendEvent"
         case skippedEventAfterDecryptionFailure = "Skipping event that failed to decrypt on channel"
         case cannotSendClientEventForChannel = "You must be subscribed to a private or presence channel to send client events"
+        case clientEventsNotSupported = "Client events are not supported on encrypted channels:"
+
+        // JSON parsing
+
+        case unableToParseStringAsJSON = "Unable to parse string as JSON:"
+
+        // Misc
+
+        case genericError = ""
 
         // Network
 

--- a/Sources/Helpers/PusherParser.swift
+++ b/Sources/Helpers/PusherParser.swift
@@ -20,10 +20,12 @@ internal struct PusherParser {
                                                                   options: []) as? [String: AnyObject] {
                 return jsonObject
             } else {
-                print("Unable to parse string from WebSocket: \(string)")
+                PusherLogger.shared.debug(for: .unableToParseStringAsJSON,
+                                          context: string)
             }
         } catch let error as NSError {
-            print("Error: \(error.localizedDescription)")
+            PusherLogger.shared.error(for: .genericError,
+                                      context: error.localizedDescription)
         }
         return nil
     }
@@ -42,7 +44,8 @@ internal struct PusherParser {
             if let jsonData = data, let jsonObject = try? JSONSerialization.jsonObject(with: jsonData, options: []) {
                 return jsonObject
             } else {
-                print("Unable to parse string as JSON - check that your JSON is valid.")
+                PusherLogger.shared.debug(for: .unableToParseStringAsJSON,
+                                          context: string)
             }
         }
         return nil

--- a/Sources/Models/PusherChannel.swift
+++ b/Sources/Models/PusherChannel.swift
@@ -172,11 +172,9 @@ open class PusherChannel: NSObject {
     */
     open func trigger(eventName: String, data: Any) {
         if PusherEncryptionHelpers.isEncryptedChannel(channelName: self.name) {
-            let error = """
-            ERROR: Client events are not supported on encrypted channels: '\(self.name)'. \
-            Client event '\(eventName)' will not be sent.
-            """
-            print(error)
+            let context = "'\(self.name)'. Client event '\(eventName)' will not be sent"
+            PusherLogger.shared.error(for: .clientEventsNotSupported,
+                                      context: context)
             return
         }
 

--- a/Sources/Models/PusherPresenceChannel.swift
+++ b/Sources/Models/PusherPresenceChannel.swift
@@ -138,10 +138,12 @@ public typealias PusherUserInfoObject = [String: AnyObject]
                                                                   options: []) as? [String: AnyObject] {
                 return jsonObject
             } else {
-                print("Unable to parse string: \(channelData)")
+                PusherLogger.shared.debug(for: .unableToParseStringAsJSON,
+                                          context: channelData)
             }
         } catch let error as NSError {
-            print(error.localizedDescription)
+            PusherLogger.shared.error(for: .genericError,
+                                      context: error.localizedDescription)
         }
         return nil
     }

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -57,14 +57,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
         let isEncryptedChannel = PusherEncryptionHelpers.isEncryptedChannel(channelName: channelName)
 
         if isEncryptedChannel && auth != nil {
-            let error = """
-
-            WARNING: Passing an auth value to 'subscribe' is not supported for encrypted channels. \
-            Event decryption will fail. You must use one of the following auth methods: \
-            'endpoint', 'authRequestBuilder', 'authorizer'
-
-            """
-            print(error)
+            PusherLogger.shared.warning(for: .authValueOnSubscriptionNotSupported)
         }
 
         return self.connection.subscribe(

--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -112,7 +112,8 @@ import NWWebSocket
             guard self.connectionState == .connected else { return newChannel }
 
             if !self.authorize(newChannel, auth: auth) {
-                print("Unable to subscribe to channel: \(newChannel.name)")
+                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToSubscribeToChannel,
+                                                                     context: newChannel.name))
             }
 
             return newChannel
@@ -148,7 +149,8 @@ import NWWebSocket
         guard self.connectionState == .connected else { return newChannel }
 
         if !self.authorize(newChannel, auth: auth) {
-            print("Unable to subscribe to channel: \(newChannel.name)")
+            self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToSubscribeToChannel,
+                                                                 context: newChannel.name))
         }
 
         return newChannel
@@ -218,7 +220,7 @@ import NWWebSocket
                                                                      context: dataString))
                 self.socket.send(string: dataString)
             } else {
-                print("You must be subscribed to a private or presence channel to send client events")
+                self.delegate?.debugLog?(message: PusherLogger.debug(for: .cannotSendClientEventForChannel))
             }
         }
     }
@@ -498,7 +500,8 @@ import NWWebSocket
     fileprivate func attemptSubscriptionsToUnsubscribedChannels() {
         for (_, channel) in self.channels.channels {
             if !self.authorize(channel, auth: channel.auth) {
-                print("Unable to subscribe to channel: \(channel.name)")
+                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToSubscribeToChannel,
+                                                                     context: channel.name))
             }
         }
     }
@@ -514,7 +517,7 @@ import NWWebSocket
             if let memberJSON = event.dataToJSONObject() as? [String: Any] {
                 chan.addMember(memberJSON: memberJSON)
             } else {
-                print("Unable to add member")
+                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToAddMemberToChannel))
             }
         }
     }
@@ -530,7 +533,7 @@ import NWWebSocket
             if let memberJSON = event.dataToJSONObject() as? [String: Any] {
                 chan.removeMember(memberJSON: memberJSON)
             } else {
-                print("Unable to remove member")
+                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToRemoveMemberFromChannel))
             }
         }
     }
@@ -565,9 +568,6 @@ import NWWebSocket
                 self.handleEvent(event: event)
             }
 
-            if let message = error.message {
-                print(message)
-            }
             self.delegate?.failedToSubscribeToChannel?(name: channelName,
                                                        response: error.response,
                                                        data: error.data,
@@ -683,7 +683,8 @@ import NWWebSocket
         case .authorizer(authorizer: let authorizer):
             authorizer.fetchAuthValue(socketID: socketId, channelName: channel.name) { pusherAuth in
                 if pusherAuth == nil {
-                    print("Auth info passed to authorizer completionHandler was nil")
+                    self.delegate?.debugLog?(message: PusherLogger.debug(for:
+                                                                            .authInfoForCompletionHandlerIsNil))
                 }
                 completionHandler(pusherAuth, nil)
             }
@@ -733,7 +734,7 @@ import NWWebSocket
             if let socketId = self.socketId {
                 return JSONStringify([Constants.JSONKeys.userId: socketId])
             } else {
-                print("Authentication failed. You may not be connected")
+                self.delegate?.debugLog?(message: PusherLogger.debug(for: .authenticationFailed))
                 return ""
             }
         }

--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -18,7 +18,12 @@ import NWWebSocket
     open var reconnectAttemptsMax: Int?
     open var reconnectAttempts: Int = 0
     open var maxReconnectGapInSeconds: Double? = 120
-    open weak var delegate: PusherDelegate?
+    open weak var delegate: PusherDelegate? = nil {
+        // Set the delegate for logging purposes via `debugLog(message:)`
+        didSet {
+            PusherLogger.shared.delegate = self.delegate
+        }
+    }
     open var pongResponseTimeoutInterval: TimeInterval = 30
     open var activityTimeoutInterval: TimeInterval
     var reconnectTimer: Timer?
@@ -112,8 +117,8 @@ import NWWebSocket
             guard self.connectionState == .connected else { return newChannel }
 
             if !self.authorize(newChannel, auth: auth) {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToSubscribeToChannel,
-                                                                     context: newChannel.name))
+                PusherLogger.shared.debug(for: .unableToSubscribeToChannel,
+                                          context: newChannel.name)
             }
 
             return newChannel
@@ -149,8 +154,8 @@ import NWWebSocket
         guard self.connectionState == .connected else { return newChannel }
 
         if !self.authorize(newChannel, auth: auth) {
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToSubscribeToChannel,
-                                                                 context: newChannel.name))
+            PusherLogger.shared.debug(for: .unableToSubscribeToChannel,
+                                      context: newChannel.name)
         }
 
         return newChannel
@@ -197,8 +202,8 @@ import NWWebSocket
         } else {
             let dataString = JSONStringify([Constants.JSONKeys.event: event,
                                             Constants.JSONKeys.data: data])
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .eventSent,
-                                                                 context: dataString))
+            PusherLogger.shared.debug(for: .eventSent,
+                                      context: dataString)
             self.socket.send(string: dataString)
         }
     }
@@ -216,11 +221,11 @@ import NWWebSocket
                 let dataString = JSONStringify([Constants.JSONKeys.event: event,
                                                 Constants.JSONKeys.data: data,
                                                 Constants.JSONKeys.channel: channel.name] as [String: Any])
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .clientEventSent,
-                                                                     context: dataString))
+                PusherLogger.shared.debug(for: .clientEventSent,
+                                          context: dataString)
                 self.socket.send(string: dataString)
             } else {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .cannotSendClientEventForChannel))
+                PusherLogger.shared.debug(for: .cannotSendClientEventForChannel)
             }
         }
     }
@@ -400,7 +405,7 @@ import NWWebSocket
     */
     @objc fileprivate func sendPing() {
         socket.ping()
-        self.delegate?.debugLog?(message: PusherLogger.debug(for: .pingSent))
+        PusherLogger.shared.debug(for: .pingSent)
         self.setupPongResponseTimeoutTimer()
     }
 
@@ -439,7 +444,7 @@ import NWWebSocket
             chan.subscribed = true
 
             guard event.data != nil else {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .subscriptionSucceededNoDataInPayload))
+                PusherLogger.shared.debug(for: .subscriptionSucceededNoDataInPayload)
                 return
             }
 
@@ -479,8 +484,8 @@ import NWWebSocket
         if let connectionData = event.dataToJSONObject() as? [String: Any],
             let socketId = connectionData[Constants.JSONKeys.socketId] as? String {
             self.socketId = socketId
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .connectionEstablished,
-                                                                 context: socketId))
+            PusherLogger.shared.debug(for: .connectionEstablished,
+                                      context: socketId)
             self.reconnectAttempts = 0
             self.reconnectTimer?.invalidate()
 
@@ -500,8 +505,8 @@ import NWWebSocket
     fileprivate func attemptSubscriptionsToUnsubscribedChannels() {
         for (_, channel) in self.channels.channels {
             if !self.authorize(channel, auth: channel.auth) {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToSubscribeToChannel,
-                                                                     context: channel.name))
+                PusherLogger.shared.debug(for: .unableToSubscribeToChannel,
+                                          context: channel.name)
             }
         }
     }
@@ -517,7 +522,7 @@ import NWWebSocket
             if let memberJSON = event.dataToJSONObject() as? [String: Any] {
                 chan.addMember(memberJSON: memberJSON)
             } else {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToAddMemberToChannel))
+                PusherLogger.shared.debug(for: .unableToAddMemberToChannel)
             }
         }
     }
@@ -533,7 +538,7 @@ import NWWebSocket
             if let memberJSON = event.dataToJSONObject() as? [String: Any] {
                 chan.removeMember(memberJSON: memberJSON)
             } else {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToRemoveMemberFromChannel))
+                PusherLogger.shared.debug(for: .unableToRemoveMemberFromChannel)
             }
         }
     }
@@ -631,7 +636,7 @@ import NWWebSocket
             } else if let channelData = auth.channelData {
                 self.handlePresenceChannelAuth(authValue: auth.auth, channel: channel, channelData: channelData)
             } else {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .presenceChannelSubscriptionAttemptWithoutChannelData))
+                PusherLogger.shared.debug(for: .presenceChannelSubscriptionAttemptWithoutChannelData)
                 return false
             }
             return true
@@ -683,8 +688,7 @@ import NWWebSocket
         case .authorizer(authorizer: let authorizer):
             authorizer.fetchAuthValue(socketID: socketId, channelName: channel.name) { pusherAuth in
                 if pusherAuth == nil {
-                    self.delegate?.debugLog?(message: PusherLogger.debug(for:
-                                                                            .authInfoForCompletionHandlerIsNil))
+                    PusherLogger.shared.debug(for: .authInfoForCompletionHandlerIsNil)
                 }
                 completionHandler(pusherAuth, nil)
             }
@@ -734,7 +738,7 @@ import NWWebSocket
             if let socketId = self.socketId {
                 return JSONStringify([Constants.JSONKeys.userId: socketId])
             } else {
-                self.delegate?.debugLog?(message: PusherLogger.debug(for: .authenticationFailed))
+                PusherLogger.shared.debug(for: .authenticationFailed)
                 return ""
             }
         }
@@ -905,8 +909,8 @@ import NWWebSocket
 extension PusherConnection: PusherEventQueueDelegate {
     func eventQueue(_ eventQueue: PusherEventQueue, didReceiveInvalidEventWithPayload payload: PusherEventPayload) {
         DispatchQueue.main.async {
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .unableToHandleIncomingMessage,
-                                                                 context: payload))
+            PusherLogger.shared.debug(for: .unableToHandleIncomingMessage,
+                                      context: payload)
         }
     }
 
@@ -918,8 +922,8 @@ extension PusherConnection: PusherEventQueueDelegate {
                 let data = payload[Constants.JSONKeys.data] as? String
                 self.delegate?.failedToDecryptEvent?(eventName: eventName, channelName: channelName, data: data)
             }
-            self.delegate?.debugLog?(message: PusherLogger.debug(for: .skippedEventAfterDecryptionFailure,
-                                                                 context: channelName))
+            PusherLogger.shared.debug(for: .skippedEventAfterDecryptionFailure,
+                                      context: channelName)
         }
     }
 


### PR DESCRIPTION
This PR resolves #198

The SDK can now ensures all logging statements are passed to the `PusherDelegate` `debugLog(message:)` method. This means that some logging messages that were previously `print()` statements can now be silenced by users of the SDK.

- Refactors `PusherLogger` to call the `PusherDelegate` `debugLog(message:)` method internally
  - Adds a shared instance of the logger
  - Adds a `delegate` property which is set automatically when the `PusherConnection` `delegate` is set. (This is used to call `debugLog(message:)`).
- Removes all instances of `print()` logging statements.