### PR TITLE
Enhanced thread safety for common 'PusherChannel' operations

### DIFF
--- a/Sources/Models/PusherChannel.swift
+++ b/Sources/Models/PusherChannel.swift
@@ -47,15 +47,15 @@ open class PusherChannel: NSObject {
     public var auth: PusherAuth?
 
     // Wrap accesses to the decryption key in a serial queue because it will be accessed from multiple threads
-    @nonobjc private var decryptionKeyQueue = DispatchQueue(label: "com.pusher.pusherswift-channel-decryption-key-\(UUID().uuidString)")
+    @nonobjc private var decryptionKeyQueue = DispatchQueue(label: "com.pusher.pusherswift-channel-decryption-key-\(UUID().uuidString)",
+                                                            attributes: .concurrent)
     @nonobjc private var decryptionKeyInternal: String?
     @nonobjc internal var decryptionKey: String? {
         get {
             return decryptionKeyQueue.sync { decryptionKeyInternal }
         }
-
         set {
-            decryptionKeyQueue.sync { decryptionKeyInternal = newValue }
+            decryptionKeyQueue.async(flags: .barrier) { self.decryptionKeyInternal = newValue }
         }
     }
 


### PR DESCRIPTION
This PR resolves #219 and resolves #220:

- Adds thread safe access to internal dictionaries which are modified when binding / unbinding events to a channel, and when subscribing / unsubscribing to a channel.
- Optimises the thread safe access to the internal `decriptionKey` property of a channel to mirror the above changes.

**NOTES:**
- Reference example: https://uynguyen.github.io/2018/06/05/Working-In-Thread-Safe-on-iOS/