### PR TITLE
Mark stale channel object as unsubscribed

### DIFF
--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -178,6 +178,7 @@ import NWWebSocket
         )
 
         self.channels.remove(name: channelName)
+        chan.subscribed = false
     }
 
     /**


### PR DESCRIPTION
### Description of the pull request

The connection does not mark the channel as unsubscribed after unsubscribing. The channels are detached from PusherChannels at this point already.

#### Why is the change necessary?

This change makes sure the channel's subscribed flag is consistent with its actual state.