### PR TITLE
Mark legacy 'bind(…)' methods as deprecated

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,4 +13,4 @@ identifier_name:
 
 # This generates a compiler error if more than this many SwiftLint warnings are present
 # (This threshold can become more restrictive as remaining warnings are resolved via refactoring)
-warning_threshold: 21
+warning_threshold: 13

--- a/Sources/Models/PusherChannel.swift
+++ b/Sources/Models/PusherChannel.swift
@@ -90,6 +90,7 @@ open class PusherChannel: NSObject {
 
         - returns: A unique callbackId that can be used to unbind the callback at a later time
     */
+    @available(*, deprecated, message: "This will be removed in v10.0.0. Use 'bind(eventName:eventCallback:)' instead.")
     @discardableResult open func bind(eventName: String, callback: @escaping (Any?) -> Void) -> String {
         return bind(eventName: eventName, eventCallback: { [weak self] (event: PusherEvent) -> Void in
             guard let self = self else { return }

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -121,6 +121,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
 
         - returns: A unique string that can be used to unbind the callback from the client
     */
+    @available(*, deprecated, message: "This will be removed in v10.0.0. Use 'bind(eventCallback:)' instead.")
     @discardableResult open func bind(_ callback: @escaping (Any?) -> Void) -> String {
         return self.connection.addLegacyCallbackToGlobalChannel(callback)
     }

--- a/Tests/Helpers/Helpers.swift
+++ b/Tests/Helpers/Helpers.swift
@@ -12,7 +12,7 @@ func convertStringToDictionary(_ text: String) -> [String: AnyObject]? {
         return json
     } catch {
         print("Something went wrong")
-        
+
         return nil
     }
 }

--- a/Tests/Integration/AuthenticationTests.swift
+++ b/Tests/Integration/AuthenticationTests.swift
@@ -1,7 +1,5 @@
 import XCTest
 
-// swiftlint:disable nesting
-
 @testable import PusherSwift
 
 class AuthenticationTests: XCTestCase {
@@ -133,7 +131,7 @@ class AuthenticationTests: XCTestCase {
                   eventName == "pusher:subscription_error" else {
                 return
             }
-            
+
             XCTAssertEqual("private-test-channel", data["channel"] as? String)
             XCTAssertTrue(Thread.isMainThread)
             ex.fulfill()

--- a/Tests/Unit/Services/PusherConnectionTests.swift
+++ b/Tests/Unit/Services/PusherConnectionTests.swift
@@ -1,7 +1,5 @@
 import XCTest
 
-// swiftlint:disable nesting
-
 @testable import PusherSwift
 
 class PusherConnectionTests: XCTestCase {


### PR DESCRIPTION
This PR resolves #332 :

- Marks legacy 'bind(…)' methods as deprecated (these will be removed in the future v10.0.0 release).
- Resolves some SwiftLint warnings
  - Also reduces the SwiftLint warning threshold (prevents new warnings being committed in the future).