### PR TITLE
Fix missing 'NWWebSocket' in Carthage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To integrate PusherSwift into your Xcode project using Carthage, specify it in y
 github "pusher/pusher-websocket-swift"
 ```
 
-Carthage will produce a number of frameworks. You need to include the following framework binaries in your project from the `Carthage/Build` directory: `PusherSwift` and `TweetNacl`
+Carthage will produce a number of frameworks. You need to include the following framework binaries in your project from the `Carthage/Build` directory: `PusherSwift`, `NWWebSocket` and `TweetNacl`
 
 #### Xcode 12 considerations
 


### PR DESCRIPTION
### Description of the pull request

Insert missing `'NWWebSocket'` into the Carthage integration step in README.

#### Why is the change necessary?

Without that, the following error message will be displayed at runtime:

```
dyld: Library not loaded: @rpath/NWWebSocket.framework/NWWebSocket
  Referenced from: /path/to/PusherSwift.framework/PusherSwift
  Reason: image not found
```
