### PR TITLE
Additions to README for Carthage integration when using Xcode 12.0 and above

### DIFF
--- a/Consumption-Tests/Shared/carthage.sh
+++ b/Consumption-Tests/Shared/carthage.sh
@@ -10,7 +10,11 @@ trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 
 # For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
 # the build will fail on lipo due to duplicate architectures.
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+
+CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,11 @@ Carthage will produce a number of frameworks. You need to include the following 
 
 #### Xcode 12 considerations
 
-Using Carthage under Xcode 12.0 and above currently requires [a workaround](https://github.com/Carthage/Carthage/issues/3019) in order for the build to be successful. You can find an example of the workaround, which is used for running the 'Consumption-Tests' [here](Consumption-Tests/Shared/carthage.sh).
+There have been changes to the architectures included when building universal frameworks under Xcode 12.0 and above. This is to support the introduction of the Apple Silicon family of processors.
+
+It is strongly recommended that you integrate PusherSwift using the `--use-xcframeworks` flag, running Carthage `0.37.0` or above. There are [full instructions](https://github.com/Carthage/Carthage#building-platform-independent-xcframeworks-xcode-12-and-above) for this (as well as instructions for [migrating to XCFrameworks](https://github.com/Carthage/Carthage#migrating-a-project-from-framework-bundles-to-xcframeworks) if you are already integrating using Carthage).
+
+Alternatively, if you are building using an Intel Mac and do not want to migrate to build Carthage dependencies using XCFrameworks there is [a workaround](https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md) to build successfully. You can find an example of this workaround, which is used for running the 'Consumption-Tests' [here](Consumption-Tests/Shared/carthage.sh).
 
 ### Swift Package Manager
 


### PR DESCRIPTION
Carthage has recently released version `0.37.0`, which includes support for building dependencies using XCFrameworks. This improves the experience of building Carthage dependencies using Xcode 12.0 and above, as the previous workaround is no longer required.

This PR:

- Adds additional information and links to the README to the Carthage integration instructions when using Xcode 12.0 and above.
- Updates the example Carthage workaround script to the latest version (taken from the Carthage repo).