### PR TITLE
Performance optimisations for higher-order functions usage

### DIFF
--- a/Sources/Models/PusherPresenceChannel.swift
+++ b/Sources/Models/PusherPresenceChannel.swift
@@ -160,7 +160,7 @@ public typealias PusherUserInfoObject = [String: AnyObject]
         - returns: The PusherPresenceChannelMember object for the given user id
     */
     open func findMember(userId: String) -> PusherPresenceChannelMember? {
-        return self.members.filter({ $0.userId == userId }).first
+        return self.members.first(where: { $0.userId == userId })
     }
 
     /**

--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -475,7 +475,7 @@ import NWWebSocket
 
         chan.auth = nil
 
-        while chan.unsentEvents.count > 0 {
+        while !chan.unsentEvents.isEmpty {
             if let pusherEvent = chan.unsentEvents.popLast() {
                 chan.trigger(eventName: pusherEvent.name, data: pusherEvent.data)
             }


### PR DESCRIPTION
This PR makes some performance optimisations in a couple of places where higher-order functions are used to modify or inspect collections:

- Replaces an instance of `filter` followed by `first` on a Collection with `first(where:)`
- Replaces an instance of `.count > 0` with `.isEmpty == false`
