### PR TITLE
Removes deprecated legacy 'bind(…)' methods

### DIFF
--- a/Sources/Models/PusherChannel.swift
+++ b/Sources/Models/PusherChannel.swift
@@ -35,10 +35,6 @@ open class PusherChannel: NSObject {
         }
     }
 
-    internal var shouldParseJSONForLegacyCallbacks: Bool {
-        return connection?.options.attemptToReturnJSONObject ?? true
-    }
-
     /**
         Initializes a new PusherChannel with a given name and connection
 
@@ -54,37 +50,6 @@ open class PusherChannel: NSObject {
         self.connection = connection
         self.auth = auth
         self.type = PusherChannelType(name: name)
-    }
-
-    /**
-        Binds a callback to a given event name, scoped to the PusherChannel the function is
-        called on
-
-        - parameter eventName: The name of the event to bind to
-        - parameter callback:  The function to call when a new event is received. The
-                               callback receives the event's data payload
-
-        - returns: A unique callbackId that can be used to unbind the callback at a later time
-    */
-    @available(*, deprecated, message: "This will be removed in v10.0.0. Use 'bind(eventName:eventCallback:)' instead.")
-    @discardableResult open func bind(eventName: String, callback: @escaping (Any?) -> Void) -> String {
-        return bind(eventName: eventName, eventCallback: { [weak self] (event: PusherEvent) -> Void in
-            guard let self = self else { return }
-            // Mimic the old parsing behavior for backwards compatibility
-            let callbackData: Any?
-            if self.shouldParseJSONForLegacyCallbacks {
-                if let data = event.dataToJSONObject() {
-                    // Parsed data
-                    callbackData = data
-                } else {
-                    // Unparsed string if we couldn't parse
-                    callbackData = event.data
-                }
-            } else {
-                callbackData = event.raw[Constants.JSONKeys.data]
-            }
-            callback(callbackData)
-        })
     }
 
     /**

--- a/Sources/Models/PusherError.swift
+++ b/Sources/Models/PusherError.swift
@@ -10,9 +10,6 @@ open class PusherError: NSObject {
     /// The error message.
     public let message: String
 
-    // The websocket payload which needs to passed to legacy callbacks for backwards compatibility
-    @nonobjc internal let raw: [String: Any]
-
     @nonobjc internal init?(jsonObject: [String: Any]) {
         guard let data = jsonObject[Constants.JSONKeys.data] as? [String: Any] else {
             return nil
@@ -24,6 +21,5 @@ open class PusherError: NSObject {
 
         self.code = data[Constants.JSONKeys.code] as? Int
         self.message = message
-        self.raw = jsonObject
     }
 }

--- a/Sources/Models/PusherGlobalChannel.swift
+++ b/Sources/Models/PusherGlobalChannel.swift
@@ -3,7 +3,6 @@ import Foundation
 @objcMembers
 @objc open class GlobalChannel: PusherChannel {
     open var globalCallbacks: [String: (PusherEvent) -> Void] = [:]
-    open var globalLegacyCallbacks: [String: (Any?) -> Void] = [:]
 
     /**
         Initializes a new GlobalChannel instance
@@ -29,17 +28,6 @@ import Foundation
     }
 
     /**
-     Calls the appropriate legacy callbacks for the given event name in the scope of the global channel
-
-     - parameter event: The JSON object received from the websocket
-     */
-    internal func handleGlobalEventLegacy(event: [String: Any]) {
-        for (_, callback) in self.globalLegacyCallbacks {
-            callback(event)
-        }
-    }
-
-    /**
         Binds a callback to the global channel
 
         - parameter callback:  The function to call when a message is received
@@ -53,26 +41,12 @@ import Foundation
     }
 
     /**
-     Binds a callback to the global channel
-
-     - parameter callback:  The function to call when a message is received
-
-     - returns: A unique callbackId that can be used to unbind the callback at a later time
-     */
-    internal func bindLegacy(_ callback: @escaping (Any?) -> Void) -> String {
-        let randomId = UUID().uuidString
-        self.globalLegacyCallbacks[randomId] = callback
-        return randomId
-    }
-
-    /**
         Unbinds the callback with the given callbackId from the global channel
 
         - parameter callbackId: The unique callbackId string used to identify which callback to unbind
     */
     internal func unbind(callbackId: String) {
         globalCallbacks.removeValue(forKey: callbackId)
-        globalLegacyCallbacks.removeValue(forKey: callbackId)
     }
 
     /**
@@ -80,6 +54,5 @@ import Foundation
     */
     override open func unbindAll() {
         globalCallbacks = [:]
-        globalLegacyCallbacks = [:]
     }
 }

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -114,19 +114,6 @@ let CLIENT_NAME = "pusher-websocket-swift"
     }
 
     /**
-        Binds the client's global channel to all events
-
-        - parameter callback: The function to call when a new event is received. The callback
-                              receives the event's data payload
-
-        - returns: A unique string that can be used to unbind the callback from the client
-    */
-    @available(*, deprecated, message: "This will be removed in v10.0.0. Use 'bind(eventCallback:)' instead.")
-    @discardableResult open func bind(_ callback: @escaping (Any?) -> Void) -> String {
-        return self.connection.addLegacyCallbackToGlobalChannel(callback)
-    }
-
-    /**
      Binds the client's global channel to all events
 
      - parameter eventCallback: The function to call when a new event is received. The callback

--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -301,17 +301,6 @@ import NWWebSocket
     }
 
     /**
-     Add legacy callback to the connection's global channel
-
-     - parameter callback: The callback to be stored
-
-     - returns: A callbackId that can be used to remove the callback from the connection
-     */
-    internal func addLegacyCallbackToGlobalChannel(_ callback: @escaping (Any?) -> Void) -> String {
-        return globalChannel.bindLegacy(callback)
-    }
-
-    /**
         Remove the callback with id of callbackId from the connection's global channel
 
         - parameter callbackId: The unique string representing the callback to be removed
@@ -565,7 +554,6 @@ import NWWebSocket
     open func handleError(error: PusherError) {
         resetActivityTimeoutTimer()
         self.delegate?.receivedError?(error: error)
-        self.globalChannel?.handleGlobalEventLegacy(event: error.raw)
     }
 
     /**
@@ -633,7 +621,6 @@ import NWWebSocket
     */
     private func callGlobalCallbacks(event: PusherEvent) {
         globalChannel?.handleGlobalEvent(event: event)
-        globalChannel?.handleGlobalEventLegacy(event: event.raw)
     }
 
     /**

--- a/Tests/Integration/AuthenticationTests.swift
+++ b/Tests/Integration/AuthenticationTests.swift
@@ -126,8 +126,8 @@ class AuthenticationTests: XCTestCase {
         XCTAssertFalse(chan.subscribed, "the channel should not be subscribed")
 
         pusher.bind { event in
-            XCTAssertEqual("pusher:subscription_error", event.eventName)
-            XCTAssertEqual("private-test-channel", event.channelName)
+            XCTAssertEqual(event.eventName, "pusher:subscription_error")
+            XCTAssertEqual(event.channelName, "private-test-channel")
             XCTAssertTrue(Thread.isMainThread)
             ex.fulfill()
         }

--- a/Tests/Integration/AuthenticationTests.swift
+++ b/Tests/Integration/AuthenticationTests.swift
@@ -125,17 +125,12 @@ class AuthenticationTests: XCTestCase {
         let chan = pusher.subscribe("private-test-channel")
         XCTAssertFalse(chan.subscribed, "the channel should not be subscribed")
 
-        _ = pusher.bind({ (data: Any?) -> Void in
-            guard let data = data as? [String: AnyObject],
-                  let eventName = data["event"] as? String,
-                  eventName == "pusher:subscription_error" else {
-                return
-            }
-
-            XCTAssertEqual("private-test-channel", data["channel"] as? String)
+        pusher.bind { event in
+            XCTAssertEqual("pusher:subscription_error", event.eventName)
+            XCTAssertEqual("private-test-channel", event.channelName)
             XCTAssertTrue(Thread.isMainThread)
             ex.fulfill()
-        })
+        }
 
         pusher.connect()
 

--- a/Tests/Integration/PusherIncomingEventHandlingTests.swift
+++ b/Tests/Integration/PusherIncomingEventHandlingTests.swift
@@ -135,7 +135,6 @@ class HandlingIncomingEventsTests: XCTestCase {
 
         let chan = pusher.subscribe("my-channel")
         chan.bind(eventName: "test-event") { event in
-            event.dataToJSONObject() as! [String: String]
             XCTAssertEqual(event.dataToJSONObject() as! [String: String], ["test": "test string", "and": "another"])
             ex.fulfill()
         }

--- a/Tests/Unit/Models/PusherChannelTests.swift
+++ b/Tests/Unit/Models/PusherChannelTests.swift
@@ -20,25 +20,15 @@ class PusherChannelTests: XCTestCase {
     func testBindingACallbackToAChannelForAGivenEventName() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertEqual(chan.eventHandlers.count, 0, "the channel should have no callbacks")
-        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
+        chan.bind(eventName: "test-event") { _ in }
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 1, "the channel should have one callback")
-    }
-
-    func testUnbindingADataCallbackForAGivenEventNameAndCallbackId() {
-        let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
-        XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
-        let idOne = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
-        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
-        XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
-        chan.unbind(eventName: "test-event", callbackId: idOne)
-        XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 1, "the channel should have one callback for event \"test-event\"")
     }
 
     func testUnbindingAnEventCallbackForAGivenEventNameAndCallbackId() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
-        let idOne = chan.bind(eventName: "test-event", eventCallback: { (_: PusherEvent) -> Void in })
-        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
+        let idOne = chan.bind(eventName: "test-event") { _ in }
+        chan.bind(eventName: "test-event") { _ in }
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
         chan.unbind(eventName: "test-event", callbackId: idOne)
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 1, "the channel should have one callback for event \"test-event\"")
@@ -47,8 +37,8 @@ class PusherChannelTests: XCTestCase {
     func testUnbindingAllCallbacksForAGivenEventName() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertNil(chan.eventHandlers["test-event"], "the channel should have no callbacks for event \"test-event\"")
-        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
-        _ = chan.bind(eventName: "test-event", eventCallback: { (_: PusherEvent) -> Void in })
+        chan.bind(eventName: "test-event") { _ in }
+        chan.bind(eventName: "test-event") { _ in }
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 2, "the channel should have two callbacks for event \"test-event\"")
         chan.unbindAll(forEventName: "test-event")
         XCTAssertEqual(chan.eventHandlers["test-event"]?.count, 0, "the channel should have no callbacks for event \"test-event\"")
@@ -57,9 +47,9 @@ class PusherChannelTests: XCTestCase {
     func testUnbindingAllCallbacksForAGivenChannel() {
         let chan = PusherChannel(name: "test-channel", connection: MockPusherConnection())
         XCTAssertEqual(chan.eventHandlers.count, 0, "the channel should have no callbacks")
-        _ = chan.bind(eventName: "test-event", callback: { (_: Any?) -> Void in })
-        _ = chan.bind(eventName: "test-event", eventCallback: { (_: PusherEvent) -> Void in })
-        _ = chan.bind(eventName: "test-event-3", callback: { (_: Any?) -> Void in })
+        chan.bind(eventName: "test-event") { _ in }
+        chan.bind(eventName: "test-event") { _ in }
+        chan.bind(eventName: "test-event-3") { _ in }
         XCTAssertEqual(chan.eventHandlers.count, 2, "the channel should have two event names with callbacks")
         chan.unbindAll()
         XCTAssertEqual(chan.eventHandlers.count, 0, "the channel should have no callbacks")

--- a/Tests/Unit/Services/ChannelEventQueue+DecryptionTests.swift
+++ b/Tests/Unit/Services/ChannelEventQueue+DecryptionTests.swift
@@ -61,7 +61,7 @@ class ChannelEventQueueDecryptionTests: XCTestCase {
 
         eventQueueDelegate.didReceiveEvent = { eventQueue, event, channelName in
             XCTAssertEqual(event.data, expectedDecryptedPayload)
-            XCTAssertEqual("private-encrypted-channel", channelName)
+            XCTAssertEqual(channelName, "private-encrypted-channel")
             ex.fulfill()
         }
 
@@ -94,7 +94,7 @@ class ChannelEventQueueDecryptionTests: XCTestCase {
         eventQueueDelegate.didFailToDecryptEvent = { eventQueue, payload, channelName in
             let equal = NSDictionary(dictionary: jsonDict).isEqual(to: payload)
             XCTAssertTrue(equal)
-            XCTAssertEqual("private-encrypted-channel", channelName)
+            XCTAssertEqual(channelName, "private-encrypted-channel")
             ex.fulfill()
         }
 
@@ -143,7 +143,7 @@ class ChannelEventQueueDecryptionTests: XCTestCase {
 
         eventQueueDelegate.didReceiveEvent = { eventQueue, event, channelName in
             XCTAssertEqual(event.data, expectedDecryptedPayload)
-            XCTAssertEqual("private-encrypted-channel", channelName)
+            XCTAssertEqual(channelName, "private-encrypted-channel")
             receivedEv.fulfill()
         }
 
@@ -186,7 +186,7 @@ class ChannelEventQueueDecryptionTests: XCTestCase {
         eventQueueDelegate.didFailToDecryptEvent = { event, payload, channelName in
             let equal = NSDictionary(dictionary: jsonDict).isEqual(to: payload)
             XCTAssertTrue(equal)
-            XCTAssertEqual("private-encrypted-channel", channelName)
+            XCTAssertEqual(channelName, "private-encrypted-channel")
             failedEv.fulfill()
         }
 
@@ -252,13 +252,13 @@ class ChannelEventQueueDecryptionTests: XCTestCase {
         eventQueueDelegate.didFailToDecryptEvent = { event, payload, channelName in
             let equal = NSDictionary(dictionary: undecryptableEvent).isEqual(to: payload)
             XCTAssertTrue(equal)
-            XCTAssertEqual("private-encrypted-channel", channelName)
+            XCTAssertEqual(channelName, "private-encrypted-channel")
             failedEx.fulfill()
         }
 
         eventQueueDelegate.didReceiveEvent = { eventQueue, event, channelName in
             XCTAssertEqual(expectedDecryptedPayload, event.data)
-            XCTAssertEqual("private-encrypted-channel", channelName)
+            XCTAssertEqual(channelName, "private-encrypted-channel")
             successEx.fulfill()
         }
 


### PR DESCRIPTION
This PR resolves #334:

- Removes the legacy `bind(_ callback:)` method on `Pusher`.
- Removes the legacy `bind(eventName:callback:)` method on `PusherChannel`.
  - Also removes test cases that are rendered redundant as a result.