### PR TITLE
Enable the watchOS deployment target

### DIFF
--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'
+  s.watchos.deployment_target = '7.0'
 end

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'
-  s.watchos.deployment_target = '7.0'
+  s.watchos.deployment_target = '6.0'
 end


### PR DESCRIPTION
### Description of the pull request

Enable the watchOS deployment target for cocoapods.

#### Why is the change necessary?

We recently did a demo where we've ported some of our app's functionality to the Apple Watch.

To accomplish that project we pointed our dependency to the change in this PR, and as far as we can tell the library works fine on watchOS (at least as of #313)

Tested on device and simulator.