### PR TITLE
Bug fix: wrong member status when going offline then online again

### DIFF
--- a/Sources/Models/PusherPresenceChannel.swift
+++ b/Sources/Models/PusherPresenceChannel.swift
@@ -73,6 +73,7 @@ public typealias PusherUserInfoObject = [String: AnyObject]
                                 subscribed to the presence channel
     */
     internal func addExistingMembers(memberHash: [String: AnyObject]) {
+        self.members.removeAll()
         for (userId, userInfo) in memberHash {
             let member: PusherPresenceChannelMember
             if let userInfo = userInfo as? PusherUserInfoObject {


### PR DESCRIPTION
### Description of the pull request
This PR clears the members array first when adding existing members.

...

#### Why is the change necessary?
This PR addresses the following bug
- Use two devices A, B and the channel presences to show each other's online status.
- Take both of them online first.
- Take A offline, then B offline.
- Take A online, now the status of B is still online, instead of offline.

This is because when A comes online again, we are adding existing members without clearing the array.

...
