### PR TITLE
return error in completion handler if auth info is nil

### DIFF
--- a/Sources/Models/AuthError.swift
+++ b/Sources/Models/AuthError.swift
@@ -7,6 +7,7 @@ struct AuthError: Error {
         case couldNotBuildRequest
         case invalidAuthResponse
         case requestFailure
+        case authInfoIsNil
     }
 
     let kind: Kind

--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -701,8 +701,14 @@ import NWWebSocket
             authorizer.fetchAuthValue(socketID: socketId, channelName: channel.name) { pusherAuth in
                 if pusherAuth == nil {
                     Logger.shared.debug(for: .authInfoForCompletionHandlerIsNil)
+                    let errorMessage = "AuthInfo should not be nil"
+                    let error = NSError(domain: "com.pusher.PusherSwift",
+                                        code: 0,
+                                        userInfo: [NSLocalizedFailureReasonErrorKey: errorMessage])
+                    completionHandler(nil, AuthError(kind: .authInfoIsNil, message: errorMessage, error: error))
+                } else {
+                    completionHandler(pusherAuth, nil)
                 }
-                completionHandler(pusherAuth, nil)
             }
             return true
 


### PR DESCRIPTION
### Description of the pull request

return error in completion handler if the `AuthInfo` from `Authorizer` is `nil`

#### Why is the change necessary?

From the documentation

> If for whatever reason your authorization process fails then you just need to call the `completionHandler` with `nil` as the only parameter.

Getting `nil` from `Authorizer` denotes an error in the authorization. The current implementation will ignore the rest of the steps as `pusherAuth` and `error` are both `nil` and there's no way for delegates to know if the channel is subscribed successfully.

Adding this code will cause `func receivedError(error: PusherError)` to be called and the users can take appropriate action.