### PR TITLE
Prevent connection reconnect after intentionally disconnect

### DIFF
--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -358,6 +358,10 @@ import NWWebSocket
         socketConnected = false
         connectionEstablishedMessageReceived = false
         socketId = nil
+        
+        guard !intentionalDisconnect else {
+            return
+        }
 
         attemptReconnect()
     }


### PR DESCRIPTION
### Description of the pull request

This PR resolves #373 

#### Why is the change necessary?

To prevent connection reconnecting again after the user intentionally calls pusher.disconnect()
