### PR TITLE
Create a tag before sending to Cocoapods

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
           ruby-version: '2.6'
       - run: |
           gem install cocoapods
+          
+          git tag -a ${{ needs.check-release-tag.outputs.tag }} -m "${{ needs.check-release-tag.outputs.tag }}"
+          git push origin ${{ needs.check-release-tag.outputs.tag }}
+
           pod trunk push PusherSwift.podspec
           pod trunk push PusherSwiftWithEncryption.podspec
         env:


### PR DESCRIPTION
### Description of the pull request
* Create a tag before sending to Cocoapods

#### Why is the change necessary?
* CocoaPods requires a tag (or branch) to distribute the library, but we're currently creating in the last stage.