### PR TITLE
Remove WatchOS as a supported platform in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ For tutorials and more in-depth information about Pusher Channels, visit our [of
 - iOS 13.0 and above
 - macOS (OS X) 10.15 and above
 - tvOS 13.0 and above
-- watchOS 6.0 and above
 
 ### Legacy OS support
 


### PR DESCRIPTION
### Description of the pull request

Remove WatchOS as a supported platform in Readme

#### Why is the change necessary?

Low level network connections (including websocket) was not meant to be supported in WatchOS 6 and above, and has been explicitly disabled in WatchOS 9: https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos
