### PR TITLE
Deduplicate resetConnection code to ensure consistency in both paths

### DIFF
--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherSwift'
-  s.version          = '10.1.1'
+  s.version          = '10.1.2'
   s.summary          = 'A Pusher client library in Swift'
   s.homepage         = 'https://github.com/pusher/pusher-websocket-swift'
   s.license          = 'MIT'

--- a/PusherSwiftWithEncryption.podspec
+++ b/PusherSwiftWithEncryption.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherSwiftWithEncryption'
-  s.version          = '10.1.1'
+  s.version          = '10.1.2'
   s.summary          = 'A Pusher client library in Swift that supports encrypted channels'
   s.homepage         = 'https://github.com/pusher/pusher-websocket-swift'
   s.license          = 'MIT'

--- a/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
+++ b/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
@@ -50,18 +50,7 @@ extension PusherConnection: WebSocketConnectionDelegate {
     public func webSocketDidDisconnect(connection: WebSocketConnection,
                                        closeCode: NWProtocolWebSocket.CloseCode,
                                        reason: Data?) {
-        // Handles setting channel subscriptions to unsubscribed whether disconnection
-        // is intentional or not
-        if connectionState == .disconnecting || connectionState == .connected {
-            for (_, channel) in self.channels.channels {
-                channel.subscribed = false
-            }
-        }
-
-        self.connectionEstablishedMessageReceived = false
-        self.socketConnected = false
-
-        updateConnectionState(to: .disconnected)
+        resetConnection()
 
         guard !intentionalDisconnect else {
             Logger.shared.debug(for: .intentionalDisconnection)

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>10.1.1</string>
+	<string>10.1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -2,7 +2,7 @@ import Foundation
 import NWWebSocket
 
 let PROTOCOL = 7
-let VERSION = "10.1.1"
+let VERSION = "10.1.2"
 // swiftlint:disable:next identifier_name
 let CLIENT_NAME = "pusher-websocket-swift"
 

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>10.1.1</string>
+	<string>10.1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Integration/PusherClientInitializationTests.swift
+++ b/Tests/Integration/PusherClientInitializationTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import PusherSwift
 
-let VERSION = "10.1.1"
+let VERSION = "10.1.2"
 
 class ClientInitializationTests: XCTestCase {
     private var key: String!

--- a/Tests/Integration/PusherTopLevelAPITests.swift
+++ b/Tests/Integration/PusherTopLevelAPITests.swift
@@ -138,7 +138,6 @@ class PusherTopLevelApiTests: XCTestCase {
 
         let chan = pusher.subscribe(TestObjects.Event.testChannelName)
         connectionDelegate.registerCallback(connectionState: ConnectionState.disconnected) {
-            XCTAssertFalse(chan.subscribed)
             disconnected.fulfill()
         }
 
@@ -150,6 +149,7 @@ class PusherTopLevelApiTests: XCTestCase {
 
         pusher.connect()
         waitForExpectations(timeout: 0.5)
+        XCTAssertFalse(chan.subscribed)
     }
 
     /* subscribing to channels when already connected */


### PR DESCRIPTION
### Description of the pull request

This PR does a small refactor and fixes an issue where socket id isn't cleared on disconnection.

#### Why is the change necessary?

This causes a bug where, when connection is flapping as in #364, reconnecting causes the wrong socket id to be used. 

## CHANGELOG

- [FIXED] Fixed issue where stale socket id was used when reconnecting.