### PR TITLE
Swift Combine Publisher support

### DIFF
--- a/Sources/Extensions/Pusher+PublisherExtensions.swift
+++ b/Sources/Extensions/Pusher+PublisherExtensions.swift
@@ -73,8 +73,8 @@ public extension Pusher {
         
         fileprivate init(subscriber: S, pusher: Pusher, subscriptionType: SubscriptionType) {
             self.subscriber = subscriber
-            self.subscriptionType = subscriptionType
             self.pusher = pusher
+            self.subscriptionType = subscriptionType
             self.subscriptionType.bind(with: pusher, callback: eventReceived(_:))
         }
         
@@ -91,7 +91,7 @@ public extension Pusher {
     }
 }
 
-/// A type responsible for binding and unbinding to various types of Pusher events.
+/// A type responsible for binding and unbinding various types of Pusher events.
 fileprivate enum SubscriptionType {
     
     /// All events broadcast globally.

--- a/Sources/Extensions/Pusher+PublisherExtensions.swift
+++ b/Sources/Extensions/Pusher+PublisherExtensions.swift
@@ -7,7 +7,7 @@ public extension Pusher {
     /// - Parameter eventName: The event that should be received. If nil, all
     /// events are received.
     /// - Returns: A Publisher for a global Pusher event.
-    func publisher(for eventName: String? = nil) -> GlobalEventPublisher {
+    func publisher(eventName: String? = nil) -> GlobalEventPublisher {
         GlobalEventPublisher(pusher: self, eventName: eventName)
     }
     
@@ -16,7 +16,7 @@ public extension Pusher {
     ///   - channelName: The channel that should be bound to.
     ///   - eventName: The event that should be received.
     /// - Returns: A Publisher for a Pusher channel event.
-    func publisher(for channelName: String, eventName: String) -> ChannelEventPublisher {
+    func publisher(channelName: String, eventName: String) -> ChannelEventPublisher {
         ChannelEventPublisher(pusher: self, channelName: channelName, eventName: eventName)
     }
     

--- a/Sources/Extensions/Pusher+PublisherExtensions.swift
+++ b/Sources/Extensions/Pusher+PublisherExtensions.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Combine
+
+public extension Pusher {
+    
+    /// Creates a Publisher that can be used to stream global Pusher events.
+    /// - Parameter eventName: The event that should be received. If nil, all
+    /// events are received.
+    /// - Returns: A Publisher for a global Pusher event.
+    func publisher(for eventName: String? = nil) -> GlobalEventPublisher {
+        GlobalEventPublisher(pusher: self, eventName: eventName)
+    }
+    
+    /// Creates a Publisher that can be used to stream events from a Pusher channel.
+    /// - Parameters:
+    ///   - channelName: The channel that should be bound to.
+    ///   - eventName: The event that should be received.
+    /// - Returns: A Publisher for a Pusher channel event.
+    func publisher(for channelName: String, eventName: String) -> ChannelEventPublisher {
+        ChannelEventPublisher(pusher: self, channelName: channelName, eventName: eventName)
+    }
+    
+    struct GlobalEventPublisher: Publisher {
+        
+        public typealias Output = PusherEvent
+        public typealias Failure = Never
+        
+        fileprivate var pusher: Pusher
+        fileprivate var eventName: String?
+        
+        public func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
+            let subscriptionType: SubscriptionType
+            if let eventName = eventName {
+                subscriptionType = .globalEvent(eventName: eventName, callbackId: nil)
+            } else {
+                subscriptionType = .global(callbackId: nil)
+            }
+            let subscription = EventSubscription<S>(
+                subscriber: subscriber,
+                pusher: pusher,
+                subscriptionType: subscriptionType
+            )
+            subscriber.receive(subscription: subscription)
+        }
+    }
+    
+    struct ChannelEventPublisher: Publisher {
+        
+        public typealias Output = PusherEvent
+        public typealias Failure = Never
+        
+        fileprivate var pusher: Pusher
+        fileprivate var channelName: String
+        fileprivate var eventName: String
+        
+        public func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
+            let channel = pusher.subscribe(channelName)
+            let subscription = EventSubscription<S>(
+                subscriber: subscriber,
+                pusher: pusher,
+                subscriptionType: .channel(channel, eventName: eventName, callbackId: nil)
+            )
+            subscriber.receive(subscription: subscription)
+        }
+    }
+    
+    /// A Subscription that will bind to a Pusher event and notify the subscriber
+    /// when the event fires.
+    class EventSubscription<S: Subscriber>: Subscription where S.Input == PusherEvent {
+        
+        private var subscriber: S?
+        private var subscriptionType: SubscriptionType
+        private let pusher: Pusher
+        
+        fileprivate init(subscriber: S, pusher: Pusher, subscriptionType: SubscriptionType) {
+            self.subscriber = subscriber
+            self.subscriptionType = subscriptionType
+            self.pusher = pusher
+            self.subscriptionType.bind(with: pusher, callback: eventReceived(_:))
+        }
+        
+        public func request(_ demand: Subscribers.Demand) {}
+        
+        public func cancel() {
+            subscriptionType.unbind(with: pusher)
+            subscriber = nil
+        }
+        
+        func eventReceived(_ event: PusherEvent) {
+            let _ = subscriber?.receive(event)
+        }
+    }
+}
+
+/// A type responsible for housing the necessary fields for binding and unbinding
+/// Pusher events.
+fileprivate enum SubscriptionType {
+    
+    case global(callbackId: String?)
+    case globalEvent(eventName: String, callbackId: String?)
+    case channel(_: PusherChannel, eventName: String, callbackId: String?)
+    
+    mutating func bind(with pusher: Pusher, callback: @escaping (PusherEvent) -> Void) {
+        switch self {
+        case .global(.none):
+            let callbackId = pusher.bind(eventCallback: callback)
+            self = .global(callbackId: callbackId)
+        case .global(_):
+            return // Already bound.
+            
+        case .globalEvent(let eventName, .none):
+            let callbackId = pusher.bind { event in
+                guard eventName == event.eventName else { return }
+                callback(event)
+            }
+            self = .globalEvent(eventName: eventName, callbackId: callbackId)
+        case .globalEvent(_, _):
+            return // Already bound.
+            
+        case .channel(let channel, let eventName, .none):
+            let callbackId = channel.bind(eventName: eventName, eventCallback: callback)
+            self = .channel(channel, eventName: eventName, callbackId: callbackId)
+        case .channel(_, _, _):
+            return // Already bound.
+        }
+        
+        // Calling this multiple times is allowed by Pusher.
+        pusher.connect()
+    }
+    
+    func unbind(with pusher: Pusher) {
+        switch self {
+        case .global(.some(let callbackId)):
+            pusher.unbind(callbackId: callbackId)
+        case .global(.none):
+            return
+            
+        case .globalEvent(_, .some(let callbackId)):
+            pusher.unbind(callbackId: callbackId)
+        case .globalEvent(_, .none):
+            return
+            
+        case .channel(let channel, let eventName, .some(let callbackId)):
+            channel.unbind(eventName: eventName, callbackId: callbackId)
+        case .channel(_, _, .none):
+            return
+        }
+    }
+}

--- a/Sources/Extensions/Pusher+PublisherExtensions.swift
+++ b/Sources/Extensions/Pusher+PublisherExtensions.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Combine
 
+public protocol PusherPublisher: Publisher where Output == PusherEvent, Failure == Never {}
+
 public extension Pusher {
     
     /// Creates a Publisher that can be used to stream global Pusher events.
@@ -21,13 +23,10 @@ public extension Pusher {
     }
     
     /// A Publisher for global Pusher events.
-    struct GlobalEventPublisher: Publisher {
+    struct GlobalEventPublisher: PusherPublisher {
         
-        public typealias Output = PusherEvent
-        public typealias Failure = Never
-        
-        fileprivate var pusher: Pusher
-        fileprivate var eventName: String?
+        fileprivate let pusher: Pusher
+        fileprivate let eventName: String?
         
         public func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
             let subscriptionType: SubscriptionType
@@ -47,14 +46,11 @@ public extension Pusher {
     }
     
     /// A Publisher for channel-specific Pusher events.
-    struct ChannelEventPublisher: Publisher {
+    struct ChannelEventPublisher: PusherPublisher {
         
-        public typealias Output = PusherEvent
-        public typealias Failure = Never
-        
-        fileprivate var pusher: Pusher
-        fileprivate var channelName: String
-        fileprivate var eventName: String
+        fileprivate let pusher: Pusher
+        fileprivate let channelName: String
+        fileprivate let eventName: String
         
         public func receive<S>(subscriber: S) where S : Subscriber, Failure == S.Failure, Output == S.Input {
             let channel = pusher.subscribe(channelName)

--- a/Sources/Extensions/Pusher+PublisherExtensions.swift
+++ b/Sources/Extensions/Pusher+PublisherExtensions.swift
@@ -20,6 +20,7 @@ public extension Pusher {
         ChannelEventPublisher(pusher: self, channelName: channelName, eventName: eventName)
     }
     
+    /// A Publisher for global Pusher events.
     struct GlobalEventPublisher: Publisher {
         
         public typealias Output = PusherEvent
@@ -35,6 +36,7 @@ public extension Pusher {
             } else {
                 subscriptionType = .global(callbackId: nil)
             }
+            
             let subscription = EventSubscription<S>(
                 subscriber: subscriber,
                 pusher: pusher,
@@ -44,6 +46,7 @@ public extension Pusher {
         }
     }
     
+    /// A Publisher for channel-specific Pusher events.
     struct ChannelEventPublisher: Publisher {
         
         public typealias Output = PusherEvent
@@ -92,12 +95,16 @@ public extension Pusher {
     }
 }
 
-/// A type responsible for housing the necessary fields for binding and unbinding
-/// Pusher events.
+/// A type responsible for binding and unbinding to various types of Pusher events.
 fileprivate enum SubscriptionType {
     
+    /// All events broadcast globally.
     case global(callbackId: String?)
+    
+    /// Events matching `eventName` that are broadcast globally.
     case globalEvent(eventName: String, callbackId: String?)
+    
+    /// Channel-specific events.
     case channel(_: PusherChannel, eventName: String, callbackId: String?)
     
     mutating func bind(with pusher: Pusher, callback: @escaping (PusherEvent) -> Void) {
@@ -133,17 +140,17 @@ fileprivate enum SubscriptionType {
         case .global(.some(let callbackId)):
             pusher.unbind(callbackId: callbackId)
         case .global(.none):
-            return
+            return // Not bound
             
         case .globalEvent(_, .some(let callbackId)):
             pusher.unbind(callbackId: callbackId)
         case .globalEvent(_, .none):
-            return
+            return // Not bound
             
         case .channel(let channel, let eventName, .some(let callbackId)):
             channel.unbind(eventName: eventName, callbackId: callbackId)
         case .channel(_, _, .none):
-            return
+            return // Not bound
         }
     }
 }

--- a/Tests/Integration/PusherPublisherTests.swift
+++ b/Tests/Integration/PusherPublisherTests.swift
@@ -26,7 +26,7 @@ class PusherExtensionTests: XCTestCase {
     func testChannelEventStreamReceivesEvent() {
         let sinkExpectation = expectation(description: "Event received")
         let cancellable = pusher
-            .publisher(for: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
+            .publisher(channelName: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
             .sink { event in
                 let expectedData = TestObjects.Event.Data.unencryptedJSON.toJsonDict() as! [String: String]
                 XCTAssertEqual(event.channelName, TestObjects.Event.testChannelName)
@@ -48,7 +48,7 @@ class PusherExtensionTests: XCTestCase {
         var cancellables = [AnyCancellable]()
         let sink1Expectation = expectation(description: "Event received on stream 1")
         pusher
-            .publisher(for: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
+            .publisher(channelName: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
             .sink { event in
                 XCTAssertEqual(event.channelName, TestObjects.Event.testChannelName)
                 XCTAssertEqual(event.eventName, TestObjects.Event.testEventName)
@@ -59,7 +59,7 @@ class PusherExtensionTests: XCTestCase {
         
         let sink2Expectation = expectation(description: "Event received on stream 2")
         pusher
-            .publisher(for: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
+            .publisher(channelName: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
             .sink { event in
                 XCTAssertEqual(event.channelName, TestObjects.Event.testChannelName)
                 XCTAssertEqual(event.eventName, TestObjects.Event.testEventName)
@@ -78,7 +78,7 @@ class PusherExtensionTests: XCTestCase {
     
     func testChannelEventStreamUnbindsUponCancelling() throws {
         let cancellable = pusher
-            .publisher(for: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
+            .publisher(channelName: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
             .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
         
         let channel = try XCTUnwrap(pusher.connection.channels.find(name: TestObjects.Event.testChannelName))
@@ -112,7 +112,7 @@ class PusherExtensionTests: XCTestCase {
     func testGlobalEventStreamReceivesSpecificEvent() {
         let sinkExpectation = expectation(description: "Event received")
         let cancellable = pusher
-            .publisher(for: TestObjects.Event.testEventName)
+            .publisher(eventName: TestObjects.Event.testEventName)
             .sink { event in
                 let expectedData = TestObjects.Event.Data.unencryptedJSON.toJsonDict() as! [String: String]
                 XCTAssertNil(event.channelName)
@@ -141,7 +141,7 @@ class PusherExtensionTests: XCTestCase {
     
     func testSpecificGlobalEventStreamUnbindsUponCancelling() {
         let cancellable = pusher
-            .publisher(for: TestObjects.Event.testEventName)
+            .publisher(eventName: TestObjects.Event.testEventName)
             .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
         
         XCTAssertEqual(pusher.connection.globalChannel.globalCallbacks.count, 1)

--- a/Tests/Integration/PusherPublisherTests.swift
+++ b/Tests/Integration/PusherPublisherTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+
+@testable import PusherSwift
+
+class PusherExtensionTests: XCTestCase {
+    
+    private var key: String!
+    private var pusher: Pusher!
+    private var socket: MockWebSocket!
+    
+    override func setUpWithError() throws {
+        key = "testKey123"
+        pusher = Pusher(key: key)
+        socket = MockWebSocket()
+        socket.delegate = pusher.connection
+        pusher.connection.socket = socket
+    }
+    
+    override func tearDownWithError() throws {
+        pusher.unsubscribeAll()
+    }
+    
+    // MARK: - Channels
+    
+    func testChannelEventStreamReceivesEvent() {
+        let expectation = expectation(description: "Event received")
+        let cancellable = pusher
+            .publisher(for: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
+            .sink { event in
+                let expectedData = TestObjects.Event.Data.unencryptedJSON.toJsonDict() as! [String: String]
+                XCTAssertEqual(event.channelName, TestObjects.Event.testChannelName)
+                XCTAssertEqual(event.eventName, TestObjects.Event.testEventName)
+                XCTAssertEqual(event.dataToJSONObject() as! [String : String], expectedData)
+                expectation.fulfill()
+            }
+        
+        pusher.connection.webSocketDidReceiveMessage(
+            connection: socket,
+            string: TestObjects.Event.withJSON()
+        )
+        waitForExpectations(timeout: 0.5, handler: nil)
+        cancellable.cancel()
+    }
+    
+    func testChannelEventStreamUnbindsUponCancelling() {
+        let cancellable = pusher
+            .publisher(for: TestObjects.Event.testChannelName, eventName: TestObjects.Event.testEventName)
+            .sink(receiveCompletion: { _ in
+                XCTFail() // Should not be called in this test.
+            }, receiveValue: { _ in
+                XCTFail() // Should not be called in this test.
+            })
+        
+        let channel = pusher.subscribe(channelName: TestObjects.Event.testChannelName)
+        XCTAssertEqual(channel.eventHandlers[TestObjects.Event.testEventName]?.count, 1)
+        cancellable.cancel()
+        XCTAssertEqual(channel.eventHandlers[TestObjects.Event.testEventName]?.count, 0)
+    }
+    
+    // MARK: - Global events
+    
+    func testGlobalEventStreamReceivesAnyEvent() {
+        let expectation = expectation(description: "Event received")
+        let cancellable = pusher
+            .publisher()
+            .sink { event in
+                let expectedData = TestObjects.Event.Data.unencryptedJSON.toJsonDict() as! [String: String]
+                XCTAssertNil(event.channelName)
+                XCTAssertEqual(event.eventName, TestObjects.Event.testEventName)
+                XCTAssertEqual(event.dataToJSONObject() as! [String : String], expectedData)
+                expectation.fulfill()
+            }
+        
+        pusher.connection.webSocketDidReceiveMessage(
+            connection: socket,
+            string: TestObjects.Event.withoutChannelNameJSON
+        )
+        waitForExpectations(timeout: 0.5, handler: nil)
+        cancellable.cancel()
+    }
+    
+    func testGlobalEventStreamReceivesSpecificEvent() {
+        let expectation = expectation(description: "Event received")
+        let cancellable = pusher
+            .publisher(for: TestObjects.Event.testEventName)
+            .sink { event in
+                let expectedData = TestObjects.Event.Data.unencryptedJSON.toJsonDict() as! [String: String]
+                XCTAssertNil(event.channelName)
+                XCTAssertEqual(event.eventName, TestObjects.Event.testEventName)
+                XCTAssertEqual(event.dataToJSONObject() as! [String : String], expectedData)
+                expectation.fulfill()
+            }
+        
+        pusher.connection.webSocketDidReceiveMessage(
+            connection: socket,
+            string: TestObjects.Event.withoutChannelNameJSON
+        )
+        waitForExpectations(timeout: 0.5, handler: nil)
+        cancellable.cancel()
+    }
+    
+    func testGlobalEventStreamUnbindsUponCancelling() {
+        let cancellable = pusher
+            .publisher()
+            .sink(receiveCompletion: { _ in
+                XCTFail() // Should not be called in this test.
+            }, receiveValue: { _ in
+                XCTFail() // Should not be called in this test.
+            })
+        
+        XCTAssertEqual(pusher.connection.globalChannel.globalCallbacks.count, 1)
+        cancellable.cancel()
+        XCTAssertEqual(pusher.connection.globalChannel.globalCallbacks.count, 0)
+    }
+}

--- a/Tests/Integration/PusherPublisherTests.swift
+++ b/Tests/Integration/PusherPublisherTests.swift
@@ -3,7 +3,7 @@ import Combine
 
 @testable import PusherSwift
 
-class PusherExtensionTests: XCTestCase {
+class PusherPublisherTests: XCTestCase {
     
     private var key: String!
     private var pusher: Pusher!


### PR DESCRIPTION
### Description of the pull request

Hello! This pull request adds Combine Publisher support for Pusher events. This is done via an extension on the Pusher class that allows you to subscribe to channel events and global events. Below are some code examples of how this could be used.

Channel events:

```Swift
let pusher = Pusher(key: "APP_KEY")
...
pusher
    .publisher(channelName: "my-channel", eventName: "my-event")
    .sink { event in
        // Do something with the PusherEvent. 
    }
    .store(in: &cancellables)
```

All global events:

```Swift
pusher
    .publisher()
    .sink { event in
        // Do something with the global PusherEvent. 
    }
    .store(in: &cancellables)
```

Specific global events:

```Swift
pusher
    .publisher(eventName: "my-event")
    .sink { event in
        // Do something with the global PusherEvent. 
    }
    .store(in: &cancellables)
```

Here's an example of a more advanced use case:
```Swift
pusher
    .publisher(channelName: "my-channel", eventName: "my-event")
    .throttle(for: .milliseconds(500), scheduler: DispatchQueue.main, latest: true)
    .compactMap { $0.dataToJSONObject() as? [AnyHashable: Any] }
    .sink { myJSONObject in
        // do something
    }
    .store(in: &cancellables)
```


#### Why is the change necessary?

This provides an alternate approach to receiving events and is a convenient way of integrating Pusher into Combine streams. 
