### PR TITLE
Fix `Run SwiftLint autocorrect` build phase not working 

### DIFF
--- a/PusherSwift.xcodeproj/project.pbxproj
+++ b/PusherSwift.xcodeproj/project.pbxproj
@@ -560,7 +560,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint autocorrect\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint --fix\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Sources/Models/PusherChannel.swift
+++ b/Sources/Models/PusherChannel.swift
@@ -15,12 +15,12 @@ open class PusherChannel: NSObject {
             eventHandlersQueue.async(flags: .barrier) { self.eventHandlersInternal = newValue }
         }
     }
-    
-    private var _subscriptionCount: Int? = nil
+
+    private var _subscriptionCount: Int?
     public var subscriptionCount: Int? {
         get { return _subscriptionCount }
     }
-    
+
     open var subscribed = false
     public let name: String
     open weak var connection: PusherConnection?
@@ -59,7 +59,7 @@ open class PusherChannel: NSObject {
         self.type = PusherChannelType(name: name)
         self.onSubscriptionCountChanged = onSubscriptionCountChanged
     }
-    
+
     internal func updateSubscriptionCount(count: Int) {
         self._subscriptionCount = count
         self.onSubscriptionCountChanged?(count)

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -9,7 +9,7 @@ let CLIENT_NAME = "pusher-websocket-swift"
 @objcMembers
 @objc open class Pusher: NSObject {
     public let connection: PusherConnection
-    open weak var delegate: PusherDelegate? = nil {
+    open weak var delegate: PusherDelegate? {
         willSet {
             self.connection.delegate = newValue
         }

--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -18,7 +18,7 @@ import NWWebSocket
     open var reconnectAttemptsMax: Int?
     open var reconnectAttempts: Int = 0
     open var maxReconnectGapInSeconds: Double? = 120
-    open weak var delegate: PusherDelegate? = nil {
+    open weak var delegate: PusherDelegate? {
         // Set the delegate for logging purposes via `debugLog(message:)`
         didSet {
             Logger.shared.delegate = self.delegate


### PR DESCRIPTION
### Description of the pull request

Remove deprecated `autocorrect` flag of the SwiftLint and use `--fix` instead. [ref](https://github.com/realm/SwiftLint/releases/tag/0.43.0-rc.3)

#### Why is the change necessary?

It was causing carthage to fail when adding pusher to my project. Below are the logs:

> Linting Swift files at paths autocorrect
Error: No lintable files found at paths: 'autocorrect'
Command PhaseScriptExecution failed with a nonzero exit code

#### Environment
- SwiftLint 0.50.1
- Xcode 14.2
- Carthage 0.38.0
