### PR TITLE
Bump Ruby to the latest stable version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '3.2.2'
       - run: |
           gem install cocoapods
 


### PR DESCRIPTION
### Description of the pull request

Bump Ruby version to 3.2.2

#### Why is the change necessary?

Fix release process
