### PR TITLE
Fix reconnection issue

### DIFF
--- a/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
+++ b/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
@@ -233,7 +233,19 @@ extension PusherConnection: WebSocketConnectionDelegate {
         if (error as? POSIXError)?.code != .ENOTCONN {
             // Resetting connection if we receive another POSIXError
             // than ENOTCONN (57 - Socket is not connected)
-            resetConnectionAndAttemptReconnect()
+            resetConnection()
+
+            guard !intentionalDisconnect else {
+                Logger.shared.debug(for: .intentionalDisconnection)
+                return
+            }
+
+            guard reconnectAttemptsMax == nil || reconnectAttempts < reconnectAttemptsMax! else {
+                Logger.shared.debug(for: .maxReconnectAttemptsLimitReached)
+                return
+            }
+
+            attemptReconnect()
         }
     }
 }

--- a/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
+++ b/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
@@ -230,7 +230,7 @@ extension PusherConnection: WebSocketConnectionDelegate {
             Error: \(error.debugDescription)
             """)
 
-        if (error as? POSIXError)?.code != .ENOTCONN {
+        if case .posix(let code) = error, code != .ENOTCONN {
             // Resetting connection if we receive another POSIXError
             // than ENOTCONN (57 - Socket is not connected)
             resetConnection()

--- a/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
+++ b/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
@@ -229,5 +229,11 @@ extension PusherConnection: WebSocketConnectionDelegate {
                             context: """
             Error: \(error.debugDescription)
             """)
+
+        if (error as? POSIXError)?.code != .ENOTCONN {
+            // Resetting connection if we receive another POSIXError
+            // than ENOTCONN (57 - Socket is not connected)
+            resetConnectionAndAttemptReconnect()
+        }
     }
 }


### PR DESCRIPTION
### Description of the pull request

The modification aims to reestablish the connection whenever the `WebSocketConnectionDelegate` triggers the `webSocketDidReceiveError` event due to any `POSIX` error, except for `ENOTCONN` (code `57` - `Socket is not connected`).

#### Why is the change necessary?

After thorough monitoring, we observed that whenever the `WebSocketConnectionDelegate` triggers the `webSocketDidReceiveError` event due to any `POSIX` error other than `ENOTCONN`, the socket loses its connection. However, the `WebSocketConnectionDelegate` fails to call the `webSocketDidDisconnect` method, leaving the instance in a "connected" state, even though it is effectively disconnected. This situation prevents reconnection attempts, forcing users to restart the app to establish a new connection.
