### PR TITLE
Remove WatchOS from deployment target list

### DIFF
--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -18,5 +18,4 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'
   s.tvos.deployment_target = '13.0'
-  s.watchos.deployment_target = '6.0'
 end


### PR DESCRIPTION
### Description of the pull request

WatchOS does not support WebSocket to date, so we are removing it.

