### PR TITLE
Upgrade NWWebSocket to v0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [10.1.10](https://github.com/pusher/pusher-websocket-swift/compare/10.1.9...10.1.10) - 2026-03-10
+
+### Fixed
+
+- Upgrade NWWebSocket to 0.5.10 to treat all POSIX errors as disconnections, fixing zombie connections caused by ENODATA (96) and other unrecognised error codes
+
 ## [10.1.9](https://github.com/pusher/pusher-websocket-swift/compare/10.1.8...10.1.9) - 2025-12-09
 
 ### Changed

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/pusher/NWWebSocket.git",
         "state": {
           "branch": null,
-          "revision": "501c6bd6063628e1d50661a3742311d812ba6546",
-          "version": "0.5.9"
+          "revision": "3d3b8a24b17a0f079195031ca86af117fc158bef",
+          "version": "0.5.10"
         }
       },
       {

--- a/PusherSwift.podspec
+++ b/PusherSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherSwift'
-  s.version          = '10.1.9'
+  s.version          = '10.1.10'
   s.summary          = 'A Pusher client library in Swift'
   s.homepage         = 'https://github.com/pusher/pusher-websocket-swift'
   s.license          = 'MIT'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files  = ['Sources/**/*.swift']
 
   s.dependency 'PusherTweetNacl', '~> 1.2.0'
-  s.dependency 'NWWebSocket', '~> 0.5.9'
+  s.dependency 'NWWebSocket', '~> 0.5.10'
 
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'


### PR DESCRIPTION
Upgrades NWWebSocket to v0.5.10 and bumps PusherSwift to 10.1.10.

See the NWWebSocket 0.5.10 release for the fix details:
https://github.com/pusher/NWWebSocket/compare/0.5.9...0.5.10