### PR TITLE
Make Pusher reconnect handling idempotent and allow forced disconnect

### DIFF
--- a/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
+++ b/Sources/Extensions/PusherConnection+WebsocketDelegate.swift
@@ -50,12 +50,16 @@ extension PusherConnection: WebSocketConnectionDelegate {
     public func webSocketDidDisconnect(connection: WebSocketConnection,
                                        closeCode: NWProtocolWebSocket.CloseCode,
                                        reason: Data?) {
-        resetConnection()
-
-        guard !intentionalDisconnect else {
+        if intentionalDisconnect {
+            resetConnection()
             Logger.shared.debug(for: .intentionalDisconnection)
             return
         }
+
+        if terminalEventHandledForCurrentAttempt { return }
+
+        terminalEventHandledForCurrentAttempt = true
+        resetConnection()
 
         // Log the disconnection
 
@@ -105,11 +109,13 @@ extension PusherConnection: WebSocketConnectionDelegate {
      If the `closeCode` case is `.privateCode()`, then the reconnection logic is determined by
      `PusherChannelsProtocolCloseCode.ReconnectionStrategy`.
      - Parameter closeCode: The closure code received by the WebSocket connection.
-     */
+    */
     func attemptReconnect(closeCode: NWProtocolWebSocket.CloseCode = .protocolCode(.normalClosure)) {
         guard connectionState != .connected else {
             return
         }
+
+        if let reconnectTimer = reconnectTimer, reconnectTimer.isValid { return }
 
         guard reconnectAttemptsMax == nil || reconnectAttempts < reconnectAttemptsMax! else {
             return
@@ -137,13 +143,14 @@ extension PusherConnection: WebSocketConnectionDelegate {
             logReconnectionAttempt(strategy: strategy)
         }
 
-        reconnectTimer = Timer.scheduledTimer(
-            timeInterval: reconnectionAttemptTimeInterval(strategy: strategy),
-            target: self,
-            selector: #selector(connect),
-            userInfo: nil,
-            repeats: false
-        )
+        reconnectTimer = Timer.scheduledTimer(withTimeInterval: reconnectionAttemptTimeInterval(strategy: strategy),
+                                              repeats: false) { [weak self] timer in
+            guard let self = self else { return }
+
+            timer.invalidate()
+            self.reconnectTimer = nil
+            self.connect()
+        }
         reconnectAttempts += 1
     }
 
@@ -233,6 +240,10 @@ extension PusherConnection: WebSocketConnectionDelegate {
         // Resetting connection if we receive another POSIXError
         // than ENOTCONN (57 - Socket is not connected)
         if case .posix(let code) = error, code != .ENOTCONN {
+            if terminalEventHandledForCurrentAttempt { return }
+
+            terminalEventHandledForCurrentAttempt = true
+            socket.disconnect()
             resetConnection()
 
             guard !intentionalDisconnect else {

--- a/Sources/Services/PusherConnection.swift
+++ b/Sources/Services/PusherConnection.swift
@@ -30,6 +30,7 @@ import NWWebSocket
     var pongResponseTimeoutTimer: Timer?
     var activityTimeoutTimer: Timer?
     var intentionalDisconnect: Bool = false
+    var terminalEventHandledForCurrentAttempt: Bool = false
 
     var eventQueue: ChannelEventQueue
     var eventFactory: EventFactory
@@ -264,8 +265,14 @@ import NWWebSocket
         Disconnects the websocket
     */
     open func disconnect() {
-        if self.connectionState == .connected {
+        if self.connectionState == .connected
+            || self.connectionState == .connecting
+            || self.connectionState == .reconnecting
+            || self.connectionState == .disconnecting {
             intentionalDisconnect = true
+            terminalEventHandledForCurrentAttempt = true
+            reconnectTimer?.invalidate()
+            reconnectTimer = nil
             updateConnectionState(to: .disconnecting)
             self.socket.disconnect()
         }
@@ -277,6 +284,9 @@ import NWWebSocket
     open func connect() {
         // reset the intentional disconnect state
         intentionalDisconnect = false
+        terminalEventHandledForCurrentAttempt = false
+        reconnectTimer?.invalidate()
+        reconnectTimer = nil
 
         if self.connectionState == .connected {
             return
@@ -365,6 +375,10 @@ import NWWebSocket
         process
     */
     private func resetConnectionAndAttemptReconnect() {
+        guard !terminalEventHandledForCurrentAttempt else { return }
+
+        terminalEventHandledForCurrentAttempt = true
+        socket.disconnect()
         resetConnection()
 
         guard !intentionalDisconnect else {
@@ -500,6 +514,7 @@ import NWWebSocket
                             context: socketId)
         self.reconnectAttempts = 0
         self.reconnectTimer?.invalidate()
+        self.reconnectTimer = nil
 
         if options.activityTimeout == nil,
            let activityTimeoutFromServer = connectionData["activity_timeout"] as? TimeInterval {


### PR DESCRIPTION
## Summary

This PR changes `PusherSwift` reconnect and disconnect behavior so that failed connection attempts are handled once, reconnect scheduling is deduplicated, and user-initiated disconnect works even while the client is connecting or reconnecting.

The main goal is to make `PusherConnection` behave with repeated transport failures and with the updated `NWWebSocket` teardown behavior in https://github.com/pusher/NWWebSocket/pull/66, without allowing duplicate terminal callbacks or overlapping reconnect timers to interfere with recovery.

## What Changed

- `disconnect()` now works while the connection is `.connected`, `.connecting`, `.reconnecting`, or `.disconnecting`.
- `disconnect()` now invalidates and clears any pending reconnect timer before tearing down the socket.
- `connect()` now resets per-attempt terminal state and clears any pending reconnect timer before starting a fresh attempt.
- Added per-attempt terminal handling via `terminalEventHandledForCurrentAttempt` so each connection attempt is only terminated once.
- Pong-timeout recovery now disconnects the socket, resets connection state, and schedules a reconnect only once per failed attempt.
- WebSocket error handling now ignores duplicate terminal callbacks from the same failed attempt.
- Reconnect scheduling is now deduplicated so only one reconnect timer can be pending at a time.
- Successful `connection_established` events still reset reconnect attempt counters and clear any pending reconnect timer.

## Why

During investigation, `PusherConnection` could react multiple times to the same failed connection attempt through overlapping timeout, disconnect, and websocket error paths. That led to duplicate state transitions, repeated reconnect scheduling, and noisy recovery behaviour.

This change makes reconnect handling the same per attempt and ensures that user-driven disconnect takes precedence over automatic recovery.

## Behavioral Impact

- User-triggered disconnect is now allowed during active reconnect/connecting states.
- Each failed connection attempt is handled once instead of multiple times through competing callbacks.
- Only one reconnect timer can be pending at a time.
- Reconnect behavior is cleaner when the transport repeatedly fails and retries.