### PR TITLE
Fix version strings to match 10.1.10 release

### DIFF
--- a/PusherSwiftWithEncryption.podspec
+++ b/PusherSwiftWithEncryption.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source_files  = ['Sources/**/*.swift']
 
   s.dependency 'PusherTweetNacl', '~> 1.2.0'
-  s.dependency 'NWWebSocket', '~> 0.5.9'
+  s.dependency 'NWWebSocket', '~> 0.5.10'
 
   s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.15'

--- a/PusherSwiftWithEncryption.podspec
+++ b/PusherSwiftWithEncryption.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'PusherSwiftWithEncryption'
-  s.version          = '10.1.9'
+  s.version          = '10.1.10'
   s.summary          = 'A Pusher client library in Swift that supports encrypted channels'
   s.homepage         = 'https://github.com/pusher/pusher-websocket-swift'
   s.license          = 'MIT'

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '10.0'
 use_frameworks!
 
-pod 'PusherSwift', '~> 10.1.9'
+pod 'PusherSwift', '~> 10.1.10'
 ```
 
 Then, run the following command:
@@ -150,7 +150,7 @@ let package = Package(
             targets: ["YourPackage"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "10.1.9"),
+        .package(url: "https://github.com/pusher/pusher-websocket-swift.git", from: "10.1.10"),
     ],
     targets: [
         .target(

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>10.1.9</string>
+	<string>10.1.10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Sources/PusherSwift.swift
+++ b/Sources/PusherSwift.swift
@@ -2,7 +2,7 @@ import Foundation
 import NWWebSocket
 
 let PROTOCOL = 7
-let VERSION = "10.1.9"
+let VERSION = "10.1.10"
 // swiftlint:disable:next identifier_name
 let CLIENT_NAME = "pusher-websocket-swift"
 

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>10.1.9</string>
+	<string>10.1.10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Integration/PusherClientInitializationTests.swift
+++ b/Tests/Integration/PusherClientInitializationTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import PusherSwift
 
-let VERSION = "10.1.9"
+let VERSION = "10.1.10"
 
 class ClientInitializationTests: XCTestCase {
     private var key: String!


### PR DESCRIPTION
## Summary
Several version strings were not updated when 10.1.10 was released, causing the WebSocket connection URL to report `version=10.1.9` to Pusher servers for all 10.1.10 clients.

- `Sources/PusherSwift.swift`: `VERSION` `"10.1.9"` → `"10.1.10"`
- `Sources/Info.plist`: `CFBundleShortVersionString` `"10.1.9"` → `"10.1.10"`
- `Tests/Info.plist`: `CFBundleShortVersionString` `"10.1.9"` → `"10.1.10"`
- `Tests/Integration/PusherClientInitializationTests.swift`: `VERSION` fixture `"10.1.9"` → `"10.1.10"`
- `PusherSwiftWithEncryption.podspec`: `s.version` `'10.1.9'` → `'10.1.10'`
- `README.md`: install snippets updated to reference `10.1.10`